### PR TITLE
Fix make fmt (ruff lint + docstring coverage)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,4 @@
-"""
-PyCharting Interactive Demo Suite.
+"""PyCharting Interactive Demo Suite.
 
 This script provides multiple scenarios to demonstrate the flexibility of PyCharting:
 1. Various Index Types (Numeric, Pandas Datetime, Unix Timestamps).
@@ -7,10 +6,11 @@ This script provides multiple scenarios to demonstrate the flexibility of PyChar
 3. Performance (Stress Test).
 """
 
-import sys
 import time
+
 import numpy as np
 import pandas as pd
+
 from pycharting import plot, stop_server
 
 
@@ -50,64 +50,62 @@ def generate_ohlc(n: int = 1000):
     open_ = close + np.random.randn(n) * 0.5
     high = np.maximum(open_, close) + np.abs(np.random.randn(n))
     low = np.minimum(open_, close) - np.abs(np.random.randn(n))
-    
+
     # Calculate overlays
     sma_50 = sma(close, 50)
     ema_20 = ema(close, 20)
-    
+
     # Calculate subplots
     rsi = rsi_like(close, 14)
     volume = np.abs(np.random.randn(n)) * 10000 + 5000
-    
+
     overlays = {
         "SMA 50": sma_50,
         "EMA 20": ema_20,
     }
-    
+
     subplots = {
         "RSI": rsi,
         "Volume": {"data": volume, "type": "bar"},
     }
-    
+
     return open_, high, low, close, overlays, subplots
 
 
 def run_demo(choice: str):
+    """Run the selected demo scenario identified by ``choice``."""
     n = 5000  # Default size
-    
+
     open_, high, low, close, overlays, subplots = generate_ohlc(n)
     numeric_index = np.arange(n)
-    
+
     if choice == "1":
         print("\n--- Demo: Full OHLC (Numeric Index) with Indicators ---")
-        plot(numeric_index, open=open_, high=high, low=low, close=close, 
-             overlays=overlays, subplots=subplots)
-        
+        plot(numeric_index, open=open_, high=high, low=low, close=close, overlays=overlays, subplots=subplots)
+
     elif choice == "2":
         print("\n--- Demo: Full OHLC (Pandas DatetimeIndex) with Indicators ---")
         date_index = pd.date_range(start="2024-01-01", periods=n, freq="h")
-        plot(date_index, open=open_, high=high, low=low, close=close,
-             overlays=overlays, subplots=subplots)
-        
+        plot(date_index, open=open_, high=high, low=low, close=close, overlays=overlays, subplots=subplots)
+
     elif choice == "3":
         print("\n--- Demo: Full OHLC (Unix Timestamps) with Indicators ---")
         # Milliseconds since epoch
         start_ts = int(time.time() * 1000)
         # 1 hour steps
         ts_index = np.array([start_ts + i * 3600000 for i in range(n)], dtype=np.int64)
-        plot(ts_index, open=open_, high=high, low=low, close=close,
-             overlays=overlays, subplots=subplots)
-        
+        plot(ts_index, open=open_, high=high, low=low, close=close, overlays=overlays, subplots=subplots)
+
     elif choice == "4":
         print("\n--- Demo: Line Chart (Close Only) - Numeric Index with Indicators ---")
         # Only passing 'close' triggers line chart mode
         plot(numeric_index, close=close, overlays=overlays, subplots=subplots)
-        
+
     elif choice == "5":
         print("\n--- Demo: Line Chart (Close Only) - Datetime Index with Indicators ---")
         date_index = pd.date_range(start="2024-01-01", periods=n, freq="h")
         plot(date_index, close=close, overlays=overlays, subplots=subplots)
-    
+
     elif choice == "6":
         print("\n--- Demo: Single Array (Open Only) as Line with Indicators ---")
         # Should treat 'open' as the main line if it's the only one
@@ -126,8 +124,16 @@ def run_demo(choice: str):
             "RSI": subplots["RSI"],
             "Volume": {"data": signed_vol, "type": "bar"},
         }
-        plot(date_index, open=open_, high=high, low=low, close=close,
-             overlays=overlays, subplots=vol_subplots, trades=trades)
+        plot(
+            date_index,
+            open=open_,
+            high=high,
+            low=low,
+            close=close,
+            overlays=overlays,
+            subplots=vol_subplots,
+            trades=trades,
+        )
 
     elif choice == "8":
         print("\n--- Demo: Multi-Series Subplots (MACD + RSI/SMA + Scatter) ---")
@@ -155,26 +161,26 @@ def run_demo(choice: str):
             ],
             "Events": {"data": events, "type": "scatter", "color": "#9C27B0"},
         }
-        plot(date_index, open=open_, high=high, low=low, close=close,
-             overlays=overlays, subplots=multi_subplots)
+        plot(date_index, open=open_, high=high, low=low, close=close, overlays=overlays, subplots=multi_subplots)
 
     elif choice == "9":
         print("\n--- Stress Test (1 Million Points) with Indicators ---")
         n_stress = 1_000_000
-        o, h, l, c, ovr, sub = generate_ohlc(n_stress)
+        o, h, lo, c, ovr, sub = generate_ohlc(n_stress)
         idx = np.arange(n_stress)
-        plot(idx, open=o, high=h, low=l, close=c, overlays=ovr, subplots=sub)
+        plot(idx, open=o, high=h, low=lo, close=c, overlays=ovr, subplots=sub)
 
     else:
         print("Invalid choice.")
 
 
 def main():
+    """Run the interactive demo menu loop."""
     try:
         while True:
-            print("\n" + "="*40)
+            print("\n" + "=" * 40)
             print("PyCharting Feature Demos")
-            print("="*40)
+            print("=" * 40)
             print("1. Candlesticks - Numeric Index (0, 1, 2...)")
             print("2. Candlesticks - Pandas DatetimeIndex")
             print("3. Candlesticks - Unix Timestamps (ms)")
@@ -185,16 +191,16 @@ def main():
             print("8. Multi-Series - MACD, RSI/SMA, Scatter")
             print("9. Stress Test  - 1 Million Candles")
             print("0. Exit")
-            print("="*40)
-            
+            print("=" * 40)
+
             choice = input("Select a demo (0-9): ").strip()
-            
+
             if choice == "0":
                 break
-            
+
             run_demo(choice)
             input("\nPress Enter to return to menu (Server keeps running)...")
-            
+
     except KeyboardInterrupt:
         print("\nExiting...")
     finally:

--- a/src/pycharting/__init__.py
+++ b/src/pycharting/__init__.py
@@ -1,5 +1,4 @@
-"""
-PyCharting: Interactive Financial Charting Library.
+"""PyCharting: Interactive Financial Charting Library.
 
 This package provides a high-performance, interactive charting solution for financial data
 (OHLC), designed to handle large datasets efficiently. It uses a local server architecture
@@ -39,11 +38,9 @@ Exports:
     - `get_server_status`: Function to check the status of the background server.
 """
 
-from typing import Any, Dict  # re-exported types are only for type checkers
+from .api.interface import get_server_status, plot, stop_server  # type: ignore F401
 
-from .api.interface import plot, stop_server, get_server_status  # type: ignore F401
-
-__all__ = ["plot", "stop_server", "get_server_status", "__version__"]
+__all__ = ["__version__", "get_server_status", "plot", "stop_server"]
 
 # Keep this in sync with pyproject.toml
 __version__ = "0.2.14"

--- a/src/pycharting/api/interface.py
+++ b/src/pycharting/api/interface.py
@@ -1,5 +1,4 @@
-"""
-Main User Interface for PyCharting.
+"""Main User Interface for PyCharting.
 
 This module exposes the high-level functions that users interact with to create charts,
 manage the server, and check status. It bridges the gap between the user's data (numpy/pandas)
@@ -15,44 +14,46 @@ It also provides utilities for manual server control (`stop_server`, `get_server
 and Jupyter notebook integration.
 """
 
-import webbrowser
-import time
 import logging
-from typing import Optional, Dict, Any, Union
+import time
+import webbrowser
+from typing import Any
+
 import numpy as np
 import pandas as pd
 
-from pycharting.data.ingestion import DataManager
-from pycharting.core.lifecycle import ChartServer
 from pycharting.api.routes import _data_managers
+from pycharting.core.lifecycle import ChartServer
+from pycharting.data.ingestion import DataManager
 
 logger = logging.getLogger(__name__)
 
 # Global server instance
-_active_server: Optional[ChartServer] = None
+_active_server: ChartServer | None = None
 
 
 def plot(
-    index: Union[np.ndarray, pd.Series, list],
-    open: Optional[Union[np.ndarray, pd.Series, list]] = None,
-    high: Optional[Union[np.ndarray, pd.Series, list]] = None,
-    low: Optional[Union[np.ndarray, pd.Series, list]] = None,
-    close: Optional[Union[np.ndarray, pd.Series, list]] = None,
-    overlays: Optional[Dict[str, Union[np.ndarray, pd.Series, list]]] = None,
-    subplots: Optional[Dict[str, Union[np.ndarray, pd.Series, list]]] = None,
-    trades: Optional[Union[np.ndarray, pd.Series, list]] = None,
+    index: np.ndarray | pd.Series | list,
+    open: np.ndarray | pd.Series | list | None = None,
+    high: np.ndarray | pd.Series | list | None = None,
+    low: np.ndarray | pd.Series | list | None = None,
+    close: np.ndarray | pd.Series | list | None = None,
+    overlays: dict[str, np.ndarray | pd.Series | list] | None = None,
+    subplots: dict[str, np.ndarray | pd.Series | list] | None = None,
+    trades: np.ndarray | pd.Series | list | None = None,
     session_id: str = "default",
-    port: Optional[int] = None,
+    port: int | None = None,
     open_browser: bool = True,
     server_timeout: float = 2.0,
     block: bool = True,
-) -> Dict[str, Any]:
-    """
-    Generate and display an interactive OHLC (Open-High-Low-Close) or Line chart.
+) -> dict[str, Any]:
+    """Generate and display an interactive OHLC (Open-High-Low-Close) or Line chart.
 
     This function is the primary interface for PyCharting. It performs the following steps:
-    1.  **Data Ingestion:** Converts input lists, pandas Series, or numpy arrays into optimized internal formats.
-    2.  **Server Management:** Checks if a background chart server is running. If not, it starts one on a separate thread.
+    1.  **Data Ingestion:** Converts input lists, pandas Series, or numpy arrays into optimized
+        internal formats.
+    2.  **Server Management:** Checks if a background chart server is running. If not, it starts
+        one on a separate thread.
     3.  **Session Registration:** Stores the provided data under a `session_id`. This allows multiple charts to coexist
         or data to be updated.
     4.  **Browser Launch:** Automatically opens the default web browser to the generated chart URL.
@@ -61,22 +62,30 @@ def plot(
     dynamic data slicing.
 
     Args:
-        index (Union[np.ndarray, pd.Series, list]): The x-axis data (timestamps or integer indices). Must have the same length as price arrays.
+        index (Union[np.ndarray, pd.Series, list]): The x-axis data (timestamps or integer indices).
+            Must have the same length as price arrays.
         open (Optional[Union[np.ndarray, pd.Series, list]]): Opening prices.
         high (Optional[Union[np.ndarray, pd.Series, list]]): Highest prices during the interval.
         low (Optional[Union[np.ndarray, pd.Series, list]]): Lowest prices during the interval.
-        close (Optional[Union[np.ndarray, pd.Series, list]]): Closing prices. If only `close` is provided (without open/high/low),
-            a line chart will be rendered instead of candlesticks.
-        overlays (Optional[Dict[str, Union[np.ndarray, pd.Series, list]]]): A dictionary of additional series to plot *over* the main price chart.
-            Keys are labels (e.g., "SMA 50"), values are data arrays. Useful for Moving Averages, Bollinger Bands, etc.
-        subplots (Optional[Dict[str, Union[np.ndarray, pd.Series, list]]]): A dictionary of series to plot in separate panels *below* the main chart.
-            Keys are labels (e.g., "RSI", "Volume"), values are data arrays.
-        session_id (str): A unique identifier for this dataset. Use different IDs to keep multiple charts active simultaneously.
-            Defaults to "default".
-        port (Optional[int]): Specific port to run the server on. If `None` (default), a free port is automatically found.
-        open_browser (bool): If `True` (default), automatically launches the system's default web browser to view the chart.
-        server_timeout (float): Maximum time (in seconds) to wait for the server to start before proceeding. Defaults to 2.0.
-        block (bool): If `True` (default), blocks execution until the browser page is closed. Useful in Jupyter notebooks.
+        close (Optional[Union[np.ndarray, pd.Series, list]]): Closing prices. If only `close` is provided
+            (without open/high/low), a line chart will be rendered instead of candlesticks.
+        overlays (Optional[Dict[str, Union[np.ndarray, pd.Series, list]]]): A dictionary of additional series to
+            plot *over* the main price chart. Keys are labels (e.g., "SMA 50"), values are data arrays.
+            Useful for Moving Averages, Bollinger Bands, etc.
+        subplots (Optional[Dict[str, Union[np.ndarray, pd.Series, list]]]): A dictionary of series to plot in
+            separate panels *below* the main chart. Keys are labels (e.g., "RSI", "Volume"), values are data arrays.
+        trades (Optional[Union[np.ndarray, pd.Series, list]]): Trade markers aligned with `index`, encoded as
+            +1 (buy/long), -1 (sell/short), or 0 (no trade).
+        session_id (str): A unique identifier for this dataset. Use different IDs to keep multiple charts active
+            simultaneously. Defaults to "default".
+        port (Optional[int]): Specific port to run the server on. If `None` (default), a free port is
+            automatically found.
+        open_browser (bool): If `True` (default), automatically launches the system's default web browser to
+            view the chart.
+        server_timeout (float): Maximum time (in seconds) to wait for the server to start before proceeding.
+            Defaults to 2.0.
+        block (bool): If `True` (default), blocks execution until the browser page is closed. Useful in
+            Jupyter notebooks.
 
     Returns:
         Dict[str, Any]: A dictionary containing execution details:
@@ -96,15 +105,15 @@ def plot(
         n = 1000
         index = np.arange(n)
         close = np.cumsum(np.random.randn(n)) + 100
-        
+
         # 2. Simple Line Chart
         plot(index, close=close)
-        
+
         # 3. Candlestick Chart
         open_p = close + np.random.randn(n) * 0.5
         high = np.maximum(open_p, close) + np.abs(np.random.randn(n))
         low = np.minimum(open_p, close) - np.abs(np.random.randn(n))
-        
+
         plot(
             index, open_p, high, low, close,
             overlays={"SMA 20": sma},
@@ -113,7 +122,7 @@ def plot(
         ```
     """
     global _active_server
-    
+
     try:
         # Convert lists to numpy arrays for convenience
         if isinstance(index, list):
@@ -126,20 +135,22 @@ def plot(
             low = np.array(low)
         if isinstance(close, list):
             close = np.array(close)
-        
+
         # Convert overlay lists
         if overlays:
-            overlays = {
-                k: np.array(v) if isinstance(v, list) else v
-                for k, v in overlays.items()
-            }
-        
+            overlays = {k: np.array(v) if isinstance(v, list) else v for k, v in overlays.items()}
+
         if subplots:
             converted = {}
             for k, v in subplots.items():
                 if isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
                     converted[k] = [
-                        {**entry, "data": np.array(entry["data"]) if isinstance(entry.get("data"), list) else entry.get("data")}
+                        {
+                            **entry,
+                            "data": np.array(entry["data"])
+                            if isinstance(entry.get("data"), list)
+                            else entry.get("data"),
+                        }
                         for entry in v
                     ]
                 elif isinstance(v, dict):
@@ -148,11 +159,11 @@ def plot(
                 else:
                     converted[k] = np.array(v) if isinstance(v, list) else v
             subplots = converted
-        
+
         # Convert trades list
         if isinstance(trades, list):
             trades = np.array(trades)
-        
+
         # Create DataManager with validation
         logger.info("Creating DataManager...")
         data_manager = DataManager(
@@ -165,34 +176,34 @@ def plot(
             subplots=subplots,
             trades=trades,
         )
-        
+
         # Store in global session registry for API access
         _data_managers[session_id] = data_manager
         logger.info(f"Data loaded: {data_manager.length} points")
-        
+
         # Start or reuse server
         if _active_server is None or not _active_server.is_running:
             logger.info("Starting ChartServer...")
             _active_server = ChartServer(
                 host="127.0.0.1",
                 port=port,
-                auto_shutdown_timeout=3.0  # 3 seconds after disconnect
+                auto_shutdown_timeout=3.0,  # 3 seconds after disconnect
             )
             server_info = _active_server.start_server()
-            
+
             # Wait for server to be ready
             time.sleep(server_timeout)
-            
+
         else:
             logger.info("Reusing existing ChartServer...")
             server_info = _active_server.server_info
-            server_info['url'] = f"http://{server_info['host']}:{server_info['port']}"
-        
+            server_info["url"] = f"http://{server_info['host']}:{server_info['port']}"
+
         # Construct chart URL with session ID and timestamp to bust cache
         # Use viewport demo which pulls data from the API for the given session
         ts = int(time.time())
         chart_url = f"{server_info['url']}/static/viewport-demo.html?session={session_id}&v={ts}"
-        
+
         # Open browser if requested
         if open_browser:
             logger.info(f"Opening browser: {chart_url}")
@@ -201,24 +212,24 @@ def plot(
             except Exception as e:
                 logger.warning(f"Could not open browser: {e}")
                 print(f"Please open this URL manually: {chart_url}")
-        
+
         result = {
             "status": "success",
             "url": chart_url,
-            "server_url": server_info['url'],
+            "server_url": server_info["url"],
             "session_id": session_id,
             "data_points": data_manager.length,
             "server_running": _active_server.is_running if _active_server else False,
         }
-        
+
         # Print user-friendly message
-        print(f"\n✓ Chart created successfully!")
+        print("\n✓ Chart created successfully!")
         print(f"  URL: {chart_url}")
         print(f"  Data points: {data_manager.length:,}")
         if not open_browser:
-            print(f"  Open the URL above in your browser to view the chart.")
+            print("  Open the URL above in your browser to view the chart.")
         print()
-        
+
         # Block until server shutdown if requested
         if block and _active_server:  # pragma: no cover
             logger.info("Blocking until chart is closed (press Ctrl+C to force exit)...")
@@ -233,23 +244,22 @@ def plot(
                 logger.info("Interrupted by user")
                 print("\n⚠️  Interrupted - stopping server...")
                 _active_server.stop_server()
-        
-        return result
-        
+
     except Exception as e:
         logger.error(f"Error creating chart: {e}", exc_info=True)
         print(f"\n✗ Error creating chart: {e}\n")
-        
+
         return {
             "status": "error",
             "error": str(e),
             "session_id": session_id,
         }
+    else:
+        return result
 
 
 def stop_server():
-    """
-    Manually shut down the active chart server.
+    """Manually shut down the active chart server.
 
     While the server has an auto-shutdown feature (triggered after a timeout when no clients are connected),
     this function allows for immediate, manual cleanup. This is useful in scripts or notebooks where you want
@@ -266,7 +276,7 @@ def stop_server():
         ```
     """
     global _active_server
-    
+
     if _active_server and _active_server.is_running:
         logger.info("Stopping ChartServer...")
         _active_server.stop_server()
@@ -275,9 +285,8 @@ def stop_server():
         print("ⓘ No active server to stop")
 
 
-def get_server_status() -> Dict[str, Any]:
-    """
-    Retrieve the current status of the background chart server.
+def get_server_status() -> dict[str, Any]:
+    """Retrieve the current status of the background chart server.
 
     This is useful for debugging connection issues or checking if a session is still active.
 
@@ -290,14 +299,14 @@ def get_server_status() -> Dict[str, Any]:
     Example:
         ```python
         from pycharting import get_server_status
-        
+
         status = get_server_status()
         if status['running']:
             print(f"Server running at {status['server_info']['url']}")
         ```
     """
     global _active_server
-    
+
     if _active_server:
         return {
             "running": _active_server.is_running,
@@ -316,24 +325,24 @@ def get_server_status() -> Dict[str, Any]:
 def _repr_html_():
     """Jupyter notebook representation."""
     status = get_server_status()
-    if status['running']:
+    if status["running"]:
         url = f"http://{status['server_info']['host']}:{status['server_info']['port']}"
         return f'''
         <div style="padding: 10px; background: #f0f0f0; border-radius: 5px;">
             <strong>PyCharting Server</strong><br>
             Status: <span style="color: green;">●</span> Running<br>
             URL: <a href="{url}" target="_blank">{url}</a><br>
-            Active Sessions: {status['active_sessions']}
+            Active Sessions: {status["active_sessions"]}
         </div>
         '''
     else:
-        return '''
+        return """
         <div style="padding: 10px; background: #f0f0f0; border-radius: 5px;">
             <strong>PyCharting Server</strong><br>
             Status: <span style="color: red;">●</span> Stopped
         </div>
-        '''
+        """
 
 
 # Export main functions
-__all__ = ['plot', 'stop_server', 'get_server_status']
+__all__ = ["get_server_status", "plot", "stop_server"]

--- a/src/pycharting/api/routes.py
+++ b/src/pycharting/api/routes.py
@@ -1,5 +1,4 @@
-"""
-API Routes Definition for PyCharting.
+"""API Routes Definition for PyCharting.
 
 This module defines the REST API endpoints that the frontend JavaScript uses to:
 1. Fetch sliced and diced OHLC data (`/data`).
@@ -11,10 +10,11 @@ The data is served from the in-memory `_data_managers` registry, which is popula
 by the main Python process via `src.api.interface.plot()`.
 """
 
-from typing import Optional, Dict, Any
+import logging
+from typing import Any
+
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -23,20 +23,21 @@ router = APIRouter(prefix="/api", tags=["data"])
 
 # In-memory storage for active DataManager instances
 # In production, this would use a proper session/cache management
-_data_managers: Dict[str, Any] = {}
+_data_managers: dict[str, Any] = {}
 
 
 class DataResponse(BaseModel):
     """Response model for data endpoint."""
+
     index: list
-    open: Optional[list] = None
-    high: Optional[list] = None
-    low: Optional[list] = None
-    close: Optional[list] = None
-    overlays: Dict[str, list] = Field(default_factory=dict)
-    subplots: Dict[str, list] = Field(default_factory=dict)
-    subplot_meta: Optional[Dict[str, list]] = None
-    trades: Optional[list] = None
+    open: list | None = None
+    high: list | None = None
+    low: list | None = None
+    close: list | None = None
+    overlays: dict[str, list] = Field(default_factory=dict)
+    subplots: dict[str, list] = Field(default_factory=dict)
+    subplot_meta: dict[str, list] | None = None
+    trades: list | None = None
     start_index: int
     end_index: int
     total_length: int
@@ -44,18 +45,18 @@ class DataResponse(BaseModel):
 
 class ErrorResponse(BaseModel):
     """Error response model."""
+
     error: str
-    detail: Optional[str] = None
+    detail: str | None = None
 
 
 @router.get("/data", response_model=DataResponse)
 async def get_data(
     start_index: int = Query(0, ge=0, description="Start index for data slice"),
-    end_index: Optional[int] = Query(None, ge=0, description="End index for data slice"),
+    end_index: int | None = Query(None, ge=0, description="End index for data slice"),
     session_id: str = Query("default", description="Session identifier for data source"),
 ):
-    """
-    Retrieve a specific slice of OHLC data.
+    """Retrieve a specific slice of OHLC data.
 
     This endpoint is optimized for high-performance frontend rendering. Instead of sending the full dataset
     at once (which could be millions of points), the frontend requests only the necessary chunk
@@ -77,41 +78,29 @@ async def get_data(
     """
     # Check if session exists
     if session_id not in _data_managers:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{session_id}' not found. Please initialize data first."
-        )
-    
+        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found. Please initialize data first.")
+
     data_manager = _data_managers[session_id]
-    
+
     try:
         # Get data chunk
         chunk = data_manager.get_chunk(start_index, end_index)
-        
+
         # Add metadata
         actual_end = end_index if end_index is not None else data_manager.length
-        
-        return DataResponse(
-            **chunk,
-            start_index=start_index,
-            end_index=actual_end,
-            total_length=data_manager.length
-        )
-    
+
+        return DataResponse(**chunk, start_index=start_index, end_index=actual_end, total_length=data_manager.length)
+
     except Exception as e:
-        logger.error(f"Error fetching data chunk: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Error fetching data: {str(e)}"
-        )
+        logger.exception("Error fetching data chunk")
+        raise HTTPException(status_code=500, detail=f"Error fetching data: {e!s}") from e
 
 
 @router.post("/data/init")
 async def initialize_data(
     session_id: str = Query("default", description="Session identifier"),
 ):
-    """
-    Initialize a demo data session.
+    """Initialize a demo data session.
 
     This endpoint is primarily used for testing or the standalone demo mode.
     It generates synthetic random walk data and registers it under the given session ID.
@@ -123,67 +112,64 @@ async def initialize_data(
         dict: Status message and session details.
     """
     import numpy as np
+
     from pycharting.data.ingestion import DataManager
-    
+
     try:
         # Generate demo OHLC data
         n = 1000
         timestamps = np.arange(n)
-        
+
         # Simulate price movement
         price = 100.0
         open_data = []
         high = []
         low = []
         close_data = []
-        
-        for i in range(n):
+
+        for _i in range(n):
             o = price
             change = np.random.randn() * 2
             c = o + change
             h = max(o, c) + abs(np.random.randn())
-            l = min(o, c) - abs(np.random.randn())
-            
+            lo = min(o, c) - abs(np.random.randn())
+
             open_data.append(o)
             high.append(h)
-            low.append(l)
+            low.append(lo)
             close_data.append(c)
-            
+
             price = c
-        
+
         # Create DataManager
         dm = DataManager(
             index=timestamps,
             open=np.array(open_data),
             high=np.array(high),
             low=np.array(low),
-            close=np.array(close_data)
+            close=np.array(close_data),
         )
-        
+
         # Store in session
         _data_managers[session_id] = dm
-        
+
         logger.info(f"Initialized session '{session_id}' with {n} data points")
-        
+
+    except Exception as e:
+        logger.exception("Error initializing data")
+        raise HTTPException(status_code=500, detail=f"Error initializing data: {e!s}") from e
+    else:
         return {
             "session_id": session_id,
             "status": "initialized",
             "data_points": n,
-            "message": "Demo dataset created successfully"
+            "message": "Demo dataset created successfully",
         }
-    
-    except Exception as e:
-        logger.error(f"Error initializing data: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Error initializing data: {str(e)}"
-        )
 
 
 @router.get("/sessions")
 async def list_sessions():
-    """
-    List all currently active data sessions.
+    """List all currently active data sessions.
 
     Returns:
         dict: A dictionary containing a list of session objects, each with metadata
@@ -191,23 +177,21 @@ async def list_sessions():
     """
     sessions = []
     for session_id, dm in _data_managers.items():
-        sessions.append({
-            "session_id": session_id,
-            "data_points": dm.length,
-            "has_overlays": len(dm.overlays) > 0,
-            "has_subplots": len(dm.subplots) > 0,
-        })
-    
-    return {
-        "sessions": sessions,
-        "count": len(sessions)
-    }
+        sessions.append(
+            {
+                "session_id": session_id,
+                "data_points": dm.length,
+                "has_overlays": len(dm.overlays) > 0,
+                "has_subplots": len(dm.subplots) > 0,
+            }
+        )
+
+    return {"sessions": sessions, "count": len(sessions)}
 
 
 @router.delete("/sessions/{session_id}")
 async def delete_session(session_id: str):
-    """
-    Remove a data session from memory.
+    """Remove a data session from memory.
 
     This frees up resources associated with a specific dataset.
 
@@ -221,26 +205,18 @@ async def delete_session(session_id: str):
         HTTPException(404): If the session ID is not found.
     """
     if session_id not in _data_managers:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{session_id}' not found"
-        )
-    
+        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+
     del _data_managers[session_id]
     logger.info(f"Deleted session '{session_id}'")
-    
-    return {
-        "session_id": session_id,
-        "status": "deleted",
-        "message": "Session deleted successfully"
-    }
+
+    return {"session_id": session_id, "status": "deleted", "message": "Session deleted successfully"}
 
 
 @router.get("/status")
 async def api_status():
-    """
-    Get API status and statistics.
-    
+    """Get API status and statistics.
+
     Returns:
         API status information
     """
@@ -251,6 +227,6 @@ async def api_status():
             "data": "/api/data",
             "init": "/api/data/init",
             "sessions": "/api/sessions",
-            "status": "/api/status"
-        }
+            "status": "/api/status",
+        },
     }

--- a/src/pycharting/core/lifecycle.py
+++ b/src/pycharting/core/lifecycle.py
@@ -1,5 +1,4 @@
-"""
-Server Lifecycle Management for PyCharting.
+"""Server Lifecycle Management for PyCharting.
 
 This module manages the background execution and lifecycle of the PyCharting server.
 Since the main Python script (e.g., a data science notebook or script) needs to remain responsive,
@@ -8,24 +7,26 @@ the chart server runs in a separate background thread.
 This module handles:
 - **Thread Management:** Starting and stopping the server in a daemon thread.
 - **Heartbeat Monitoring:** Checking for WebSocket connections from the frontend.
-- **Auto-Shutdown:** Automatically stopping the server when the browser tab is closed (connection lost) to prevent orphaned processes.
+- **Auto-Shutdown:** Automatically stopping the server when the browser tab is closed
+  (connection lost) to prevent orphaned processes.
 """
 
+import logging
 import threading
 import time
-import logging
-from typing import Optional, Dict, Any
 from datetime import datetime
+from typing import Any
+
 import uvicorn
 from fastapi import WebSocket, WebSocketDisconnect
+
 from pycharting.core.server import create_app, find_free_port
 
 logger = logging.getLogger(__name__)
 
 
 class ChartServer:
-    """
-    A controller for managing the PyCharting background server.
+    """A controller for managing the PyCharting background server.
 
     This class encapsulates the logic for running the FastAPI/Uvicorn server in a separate thread.
     It includes a heartbeat mechanism that monitors a WebSocket connection from the frontend.
@@ -38,15 +39,14 @@ class ChartServer:
         auto_shutdown_timeout (float): Time in seconds to wait before shutting down after connection loss.
         app (FastAPI): The underlying FastAPI application instance.
     """
-    
+
     def __init__(
         self,
         host: str = "127.0.0.1",
-        port: Optional[int] = None,
+        port: int | None = None,
         auto_shutdown_timeout: float = 5.0,
     ):
-        """
-        Initialize the ChartServer controller.
+        """Initialize the ChartServer controller.
 
         Args:
             host (str): Host to bind the server to. Defaults to "127.0.0.1".
@@ -57,21 +57,22 @@ class ChartServer:
         self.host = host
         self.port = port or find_free_port()
         self.auto_shutdown_timeout = auto_shutdown_timeout
-        
-        self._server_thread: Optional[threading.Thread] = None
+
+        self._server_thread: threading.Thread | None = None
         self._server = None
         self._running = False
         self._shutdown_event = threading.Event()
-        self._last_heartbeat: Optional[datetime] = None
-        self._monitor_thread: Optional[threading.Thread] = None
+        self._last_heartbeat: datetime | None = None
+        self._monitor_thread: threading.Thread | None = None
         self._websocket_connected = False
-        
+
         # Create app with WebSocket endpoint
         self.app = create_app()
         self._add_websocket_endpoint()
-    
+
     def _add_websocket_endpoint(self):
         """Add WebSocket heartbeat endpoint to the app."""
+
         @self.app.websocket("/ws/heartbeat")
         async def websocket_heartbeat(websocket: WebSocket):  # pragma: no cover
             """WebSocket endpoint for connection monitoring."""
@@ -79,7 +80,7 @@ class ChartServer:
             self._websocket_connected = True
             self._last_heartbeat = datetime.now()
             logger.info("WebSocket client connected")
-            
+
             try:
                 while True:
                     # Wait for heartbeat from client
@@ -87,41 +88,37 @@ class ChartServer:
                     if data == "ping":
                         self._last_heartbeat = datetime.now()
                         await websocket.send_text("pong")
-                    
+
             except WebSocketDisconnect:
                 logger.info("WebSocket client disconnected")
                 self._websocket_connected = False
-            except Exception as e:
-                logger.error(f"WebSocket error: {e}")
+            except Exception:
+                logger.exception("WebSocket error")
                 self._websocket_connected = False
-    
+
     def _monitor_connection(self):
         """Monitor WebSocket connection and trigger auto-shutdown if needed."""
         while self._running and not self._shutdown_event.is_set():
             time.sleep(1)
-            
+
             if self._websocket_connected and self._last_heartbeat:  # pragma: no cover
                 # Check if heartbeat is stale
                 elapsed = (datetime.now() - self._last_heartbeat).total_seconds()
                 if elapsed > self.auto_shutdown_timeout:
-                    logger.warning(
-                        f"No heartbeat for {elapsed:.1f}s, initiating shutdown"
-                    )
+                    logger.warning(f"No heartbeat for {elapsed:.1f}s, initiating shutdown")
                     self._websocket_connected = False
                     self.stop_server()
                     break
-            
+
             elif not self._websocket_connected and self._last_heartbeat:  # pragma: no cover
                 # Client disconnected, wait for timeout then shutdown
-                logger.info(
-                    f"Waiting {self.auto_shutdown_timeout}s before auto-shutdown"
-                )
+                logger.info(f"Waiting {self.auto_shutdown_timeout}s before auto-shutdown")
                 time.sleep(self.auto_shutdown_timeout)
                 if not self._websocket_connected:
                     logger.info("Auto-shutdown triggered")
                     self.stop_server()
                     break
-    
+
     def _run_server(self):
         """Run the Uvicorn server (called in background thread)."""
         config = uvicorn.Config(
@@ -132,17 +129,16 @@ class ChartServer:
             access_log=False,
         )
         self._server = uvicorn.Server(config)
-        
+
         try:
             self._server.run()
-        except Exception as e:  # pragma: no cover
-            logger.error(f"Server error: {e}")
+        except Exception:  # pragma: no cover
+            logger.exception("Server error")
         finally:
             self._running = False
-    
-    def start_server(self) -> Dict[str, Any]:
-        """
-        Start the web server in a background daemon thread.
+
+    def start_server(self) -> dict[str, Any]:
+        """Start the web server in a background daemon thread.
 
         This method:
         1. Checks if the server is already running.
@@ -162,35 +158,27 @@ class ChartServer:
             RuntimeError: If the server is already running.
         """
         if self._running:
-            raise RuntimeError("Server is already running")
-        
+            raise RuntimeError("Server is already running")  # noqa: TRY003
+
         self._running = True
         self._shutdown_event.clear()
-        
+
         # Start server thread
-        self._server_thread = threading.Thread(
-            target=self._run_server,
-            daemon=True,
-            name="PyCharting-Server"
-        )
+        self._server_thread = threading.Thread(target=self._run_server, daemon=True, name="PyCharting-Server")
         self._server_thread.start()
-        
+
         # Start monitor thread
-        self._monitor_thread = threading.Thread(
-            target=self._monitor_connection,
-            daemon=True,
-            name="PyCharting-Monitor"
-        )
+        self._monitor_thread = threading.Thread(target=self._monitor_connection, daemon=True, name="PyCharting-Monitor")
         self._monitor_thread.start()
-        
+
         # Wait for server to start
         time.sleep(1)
-        
+
         url = f"http://{self.host}:{self.port}"
         logger.info(f"Server started at {url}")
         logger.info(f"API docs available at {url}/api/docs")
         logger.info(f"WebSocket heartbeat at ws://{self.host}:{self.port}/ws/heartbeat")
-        
+
         return {
             "host": self.host,
             "port": self.port,
@@ -198,10 +186,9 @@ class ChartServer:
             "ws_url": f"ws://{self.host}:{self.port}/ws/heartbeat",
             "running": self._running,
         }
-    
+
     def stop_server(self):
-        """
-        Gracefully stop the background server and monitor threads.
+        """Gracefully stop the background server and monitor threads.
 
         This method signals the server to shut down, closes the Uvicorn loop,
         and joins the background threads. It is safe to call multiple times.
@@ -209,35 +196,35 @@ class ChartServer:
         if not self._running:
             logger.warning("Server is not running")
             return
-        
+
         logger.info("Stopping server...")
         self._running = False
         self._shutdown_event.set()
-        
+
         # Shutdown Uvicorn server
         if self._server:
             self._server.should_exit = True
-        
+
         # Only join threads if not called from within them
         current_thread = threading.current_thread()
-        
+
         # Wait for server thread to finish
         if self._server_thread and self._server_thread.is_alive() and self._server_thread != current_thread:
             self._server_thread.join(timeout=5)
-        
+
         # Wait for monitor thread to finish
         if self._monitor_thread and self._monitor_thread.is_alive() and self._monitor_thread != current_thread:
             self._monitor_thread.join(timeout=2)
-        
+
         logger.info("Server stopped")
-    
+
     @property
     def is_running(self) -> bool:
         """Check if server is running."""
         return self._running
-    
+
     @property
-    def server_info(self) -> Dict[str, Any]:
+    def server_info(self) -> dict[str, Any]:
         """Get current server information."""
         return {
             "host": self.host,
@@ -246,17 +233,17 @@ class ChartServer:
             "websocket_connected": self._websocket_connected,
             "last_heartbeat": self._last_heartbeat.isoformat() if self._last_heartbeat else None,
         }
-    
+
     def __enter__(self):
         """Context manager entry."""
         self.start_server()
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
         self.stop_server()
         return False
-    
+
     def __repr__(self) -> str:
         """String representation."""
         status = "running" if self._running else "stopped"

--- a/src/pycharting/core/server.py
+++ b/src/pycharting/core/server.py
@@ -1,5 +1,4 @@
-"""
-Core Server Module for PyCharting.
+"""Core Server Module for PyCharting.
 
 This module implements the FastAPI-based web server that powers the interactive charts.
 It handles serving static assets (HTML, JS, CSS) and providing API endpoints for data retrieval.
@@ -14,21 +13,22 @@ Key Responsibilities:
 - **Server Execution:** Launching the Uvicorn server.
 """
 
-import socket
 import logging
+import socket
 from pathlib import Path
-from typing import Optional
-from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.staticfiles import StaticFiles
+
+import uvicorn
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
-import uvicorn
+from fastapi.staticfiles import StaticFiles
 
 
 class NoCacheStaticFiles(StaticFiles):
     """Custom StaticFiles that adds no-cache headers for development."""
-    
+
     async def get_response(self, path: str, scope) -> Response:
+        """Return the static file response with caching disabled."""
         response = await super().get_response(path, scope)
         # Add no-cache headers to prevent browser caching during development
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
@@ -36,17 +36,14 @@ class NoCacheStaticFiles(StaticFiles):
         response.headers["Expires"] = "0"
         return response
 
+
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def find_free_port(start_port: int = 8000, end_port: int = 9000) -> int:
-    """
-    Find an available TCP port in the specified range.
+    """Find an available TCP port in the specified range.
 
     This utility function iterates through a range of ports to find one that is currently
     not in use. This is crucial for ensuring the chart server can start without conflicts,
@@ -71,18 +68,17 @@ def find_free_port(start_port: int = 8000, end_port: int = 9000) -> int:
     for port in range(start_port, end_port):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(('', port))
+                s.bind(("", port))
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 return port
         except OSError:
             continue
-    
-    raise RuntimeError(f"No free port found in range {start_port}-{end_port}")
+
+    raise RuntimeError(f"No free port found in range {start_port}-{end_port}")  # noqa: TRY003
 
 
 def create_app() -> FastAPI:
-    """
-    Create and configure the FastAPI application instance.
+    """Create and configure the FastAPI application instance.
 
     This factory function initializes the FastAPI app with necessary configurations:
     - Sets up metadata (title, description, version).
@@ -105,7 +101,7 @@ def create_app() -> FastAPI:
         docs_url="/api/docs",
         redoc_url="/api/redoc",
     )
-    
+
     # Configure CORS middleware
     app.add_middleware(
         CORSMiddleware,
@@ -114,18 +110,18 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    
+
     # Set up static files directory
     static_dir = Path(__file__).parent.parent / "web" / "static"
     static_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Mount static files with no-cache headers for development
     try:
         app.mount("/static", NoCacheStaticFiles(directory=str(static_dir)), name="static")
         logger.info(f"Static files mounted from: {static_dir}")
     except Exception as e:  # pragma: no cover
         logger.warning(f"Could not mount static files: {e}")
-    
+
     # Root endpoint
     @app.get("/", response_class=HTMLResponse)
     async def root():
@@ -181,48 +177,44 @@ def create_app() -> FastAPI:
         </body>
         </html>
         """
-    
+
     # Include API routes
     from pycharting.api.routes import router as api_router
+
     app.include_router(api_router)
-    
+
     # Health check endpoint
     @app.get("/health")
     async def health_check():
         """Health check endpoint."""
         return {"status": "healthy", "service": "pycharting"}
-    
+
     # Error handlers
     @app.exception_handler(404)
     async def not_found_handler(request, exc):
         """Handle 404 errors."""
         from fastapi.responses import JSONResponse
-        return JSONResponse(
-            status_code=404,
-            content={"error": "Not found", "path": str(request.url.path)}
-        )
-    
+
+        return JSONResponse(status_code=404, content={"error": "Not found", "path": str(request.url.path)})
+
     @app.exception_handler(500)
     async def server_error_handler(request, exc):  # pragma: no cover
         """Handle 500 errors."""
         from fastapi.responses import JSONResponse
+
         logger.error(f"Server error: {exc}")
-        return JSONResponse(
-            status_code=500,
-            content={"error": "Internal server error"}
-        )
-    
+        return JSONResponse(status_code=500, content={"error": "Internal server error"})
+
     return app
 
 
 def run_server(
     host: str = "127.0.0.1",
-    port: Optional[int] = None,
+    port: int | None = None,
     auto_port: bool = True,
     reload: bool = False,
 ) -> None:
-    """
-    Launch the PyCharting web server.
+    """Launch the PyCharting web server.
 
     This function is the main entry point for running the server directly (e.g., for development).
     It handles port selection, application creation, and starting the Uvicorn server process.
@@ -265,12 +257,12 @@ def run_server(
             logger.warning(f"Port {port} is in use, finding alternative...")
             port = find_free_port(port + 1)
             logger.info(f"Using alternative port: {port}")
-    
+
     app = create_app()
-    
+
     logger.info(f"Starting PyCharting server at http://{host}:{port}")
     logger.info(f"API documentation available at http://{host}:{port}/api/docs")
-    
+
     uvicorn.run(
         app,
         host=host,

--- a/src/pycharting/data/ingestion.py
+++ b/src/pycharting/data/ingestion.py
@@ -1,5 +1,4 @@
-"""
-Data Ingestion and Validation Module.
+"""Data Ingestion and Validation Module.
 
 This module is responsible for:
 1. Validating input data for integrity and consistency (e.g., ensuring arrays are the same length).
@@ -10,28 +9,29 @@ This module is responsible for:
 The `DataManager` class is the core component here, acting as the optimized data store for a chart session.
 """
 
-from typing import Optional, Union, List, Dict, Any
-import pandas as pd
+from typing import Any
+
 import numpy as np
+import pandas as pd
 
 
 class DataValidationError(Exception):
     """Exception raised when input data fails validation checks."""
+
     pass
 
 
 def validate_input(
-    index: Union[pd.Index, np.ndarray],
-    open: Optional[Union[pd.Series, np.ndarray]] = None,
-    high: Optional[Union[pd.Series, np.ndarray]] = None,
-    low: Optional[Union[pd.Series, np.ndarray]] = None,
-    close: Optional[Union[pd.Series, np.ndarray]] = None,
-    overlays: Optional[Dict[str, Union[pd.Series, np.ndarray]]] = None,
-    subplots: Optional[Dict[str, Union[pd.Series, np.ndarray]]] = None,
-    trades: Optional[Union[pd.Series, np.ndarray, list]] = None,
-) -> Dict[str, Any]:
-    """
-    Validate and normalize input data for OHLC charting.
+    index: pd.Index | np.ndarray,
+    open: pd.Series | np.ndarray | None = None,
+    high: pd.Series | np.ndarray | None = None,
+    low: pd.Series | np.ndarray | None = None,
+    close: pd.Series | np.ndarray | None = None,
+    overlays: dict[str, pd.Series | np.ndarray] | None = None,
+    subplots: dict[str, pd.Series | np.ndarray] | None = None,
+    trades: pd.Series | np.ndarray | list | None = None,
+) -> dict[str, Any]:
+    """Validate and normalize input data for OHLC charting.
 
     Args:
         index (Union[pd.Index, np.ndarray]): The x-axis data.
@@ -41,6 +41,8 @@ def validate_input(
         close (Optional[Union[pd.Series, np.ndarray]]): Closing prices.
         overlays (Optional[Dict[str, Union[pd.Series, np.ndarray]]]): Dictionary of overlay series.
         subplots (Optional[Dict[str, Union[pd.Series, np.ndarray]]]): Dictionary of subplot series.
+        trades (Optional[Union[pd.Series, np.ndarray, list]]): Trade markers aligned with the index,
+            encoded as +1 (buy/long), -1 (sell/short), or 0 (no trade).
 
     Returns:
         Dict[str, Any]: A dictionary containing normalized `numpy.ndarray` objects for all inputs.
@@ -54,12 +56,12 @@ def validate_input(
     elif isinstance(index, np.ndarray):
         index_array = index
     else:
-        raise DataValidationError(f"Index must be a pd.Index or np.ndarray, got {type(index)}")
-    
+        raise DataValidationError(f"Index must be a pd.Index or np.ndarray, got {type(index)}")  # noqa: TRY003
+
     n = len(index_array)
 
     # Helper function to convert to numpy array
-    def to_array(data: Optional[Union[pd.Series, np.ndarray, list]], name: str) -> Optional[np.ndarray]:
+    def to_array(data: pd.Series | np.ndarray | list | None, name: str) -> np.ndarray | None:
         if data is None:
             return None
         if isinstance(data, pd.Series):
@@ -69,10 +71,10 @@ def validate_input(
         elif isinstance(data, list):
             arr = np.array(data)
         else:
-            raise DataValidationError(f"{name} must be array-like, got {type(data)}")
-        
+            raise DataValidationError(f"{name} must be array-like, got {type(data)}")  # noqa: TRY003
+
         if len(arr) != n:
-            raise DataValidationError(f"{name} length ({len(arr)}) does not match index length ({n})")
+            raise DataValidationError(f"{name} length ({len(arr)}) does not match index length ({n})")  # noqa: TRY003
         return arr
 
     # Convert inputs
@@ -84,13 +86,17 @@ def validate_input(
     # Determine Chart Mode
     # 1. Identify provided series
     provided_series = []
-    if open_arr is not None: provided_series.append(open_arr)
-    if high_arr is not None: provided_series.append(high_arr)
-    if low_arr is not None: provided_series.append(low_arr)
-    if close_arr is not None: provided_series.append(close_arr)
+    if open_arr is not None:
+        provided_series.append(open_arr)
+    if high_arr is not None:
+        provided_series.append(high_arr)
+    if low_arr is not None:
+        provided_series.append(low_arr)
+    if close_arr is not None:
+        provided_series.append(close_arr)
 
     if len(provided_series) == 0:
-        raise DataValidationError("At least one data series (Open, High, Low, or Close) must be provided.")
+        raise DataValidationError("At least one data series (Open, High, Low, or Close) must be provided.")  # noqa: TRY003
 
     if len(provided_series) == 1:
         # Single Series Mode -> Line Chart
@@ -103,21 +109,16 @@ def validate_input(
     else:
         # Multi Series Mode -> Candlestick Chart
         # Auto-fill missing data to ensure valid candles
-        
-        # 1. Ensure we have Open and Close
-        if open_arr is None and close_arr is not None:
-            final_open = close_arr # Fallback
-        else:
-            final_open = open_arr
 
-        if close_arr is None and open_arr is not None:
-            final_close = open_arr # Fallback
-        else:
-            final_close = close_arr
-            
+        # 1. Ensure we have Open and Close (fall back to the other when one is missing)
+        final_open = close_arr if open_arr is None and close_arr is not None else open_arr
+        final_close = open_arr if close_arr is None and open_arr is not None else close_arr
+
         # If both were somehow None (should be caught by len check, but logic check):
-        if final_open is None: final_open = provided_series[0]
-        if final_close is None: final_close = provided_series[0]
+        if final_open is None:
+            final_open = provided_series[0]
+        if final_close is None:
+            final_close = provided_series[0]
 
         # 2. Ensure High and Low
         # If missing, calc from open/close
@@ -130,7 +131,7 @@ def validate_input(
             final_high = high_arr
             if not np.all(final_high >= max_oc):
                 invalid_indices = np.where(final_high < max_oc)[0]
-                raise DataValidationError(
+                raise DataValidationError(  # noqa: TRY003
                     f"High must be >= max(Open, Close). Violations at indices: {invalid_indices[:5]}"
                 )
 
@@ -140,7 +141,7 @@ def validate_input(
             final_low = low_arr
             if not np.all(final_low <= min_oc):
                 invalid_indices = np.where(final_low > min_oc)[0]
-                raise DataValidationError(
+                raise DataValidationError(  # noqa: TRY003
                     f"Low must be <= min(Open, Close). Violations at indices: {invalid_indices[:5]}"
                 )
 
@@ -149,11 +150,9 @@ def validate_input(
     if trades is not None:
         trades_arr = to_array(trades, "Trades")
         unique = set(np.unique(trades_arr).tolist())
-        valid_vals = {-1, 0, 1, -1.0, 0.0, 1.0}
+        valid_vals = {-1, 0, 1, -1.0}
         if not unique.issubset(valid_vals):
-            raise DataValidationError(
-                f"Trades array must contain only -1, 0, or 1. Found: {unique - valid_vals}"
-            )
+            raise DataValidationError(f"Trades array must contain only -1, 0, or 1. Found: {unique - valid_vals}")  # noqa: TRY003
         trades_arr = trades_arr.astype(np.int8)
 
     result = {
@@ -166,13 +165,13 @@ def validate_input(
         "subplots": {},
         "trades": trades_arr,
     }
-    
+
     # Validate and convert overlays
     if overlays:
         for name, data in overlays.items():
             arr = to_array(data, f"Overlay '{name}'")
             result["overlays"][name] = arr
-    
+
     # Validate and convert subplots
     # Supported formats:
     #   "name": array                    → single line
@@ -187,55 +186,60 @@ def validate_input(
                     key = f"{name}__{idx}"
                     arr = to_array(entry.get("data"), f"Subplot '{name}[{idx}]'")
                     result["subplots"][key] = arr
-                    panel_series.append({
-                        "key": key,
-                        "type": entry.get("type", "line"),
-                        "color": entry.get("color"),
-                        "label": entry.get("label", f"{name}_{idx}"),
-                    })
+                    panel_series.append(
+                        {
+                            "key": key,
+                            "type": entry.get("type", "line"),
+                            "color": entry.get("color"),
+                            "label": entry.get("label", f"{name}_{idx}"),
+                        }
+                    )
                 subplot_meta[name] = panel_series
             elif isinstance(value, dict):
                 arr = to_array(value.get("data"), f"Subplot '{name}'")
                 result["subplots"][name] = arr
-                subplot_meta[name] = [{
-                    "key": name,
-                    "type": value.get("type", "line"),
-                    "color": value.get("color"),
-                    "label": name,
-                }]
+                subplot_meta[name] = [
+                    {
+                        "key": name,
+                        "type": value.get("type", "line"),
+                        "color": value.get("color"),
+                        "label": name,
+                    }
+                ]
             else:
                 arr = to_array(value, f"Subplot '{name}'")
                 result["subplots"][name] = arr
-                subplot_meta[name] = [{
-                    "key": name,
-                    "type": "line",
-                    "color": None,
-                    "label": name,
-                }]
+                subplot_meta[name] = [
+                    {
+                        "key": name,
+                        "type": "line",
+                        "color": None,
+                        "label": name,
+                    }
+                ]
     result["subplot_meta"] = subplot_meta
-    
+
     return result
 
 
 class DataManager:
-    """
-    High-performance data container and manager.
-    """
-    
+    """High-performance data container and manager."""
+
     def __init__(
         self,
-        index: Union[pd.Index, np.ndarray],
-        open: Optional[Union[pd.Series, np.ndarray]] = None,
-        high: Optional[Union[pd.Series, np.ndarray]] = None,
-        low: Optional[Union[pd.Series, np.ndarray]] = None,
-        close: Optional[Union[pd.Series, np.ndarray]] = None,
-        overlays: Optional[Dict[str, Union[pd.Series, np.ndarray]]] = None,
-        subplots: Optional[Dict[str, Union[pd.Series, np.ndarray]]] = None,
-        trades: Optional[Union[pd.Series, np.ndarray, list]] = None,
+        index: pd.Index | np.ndarray,
+        open: pd.Series | np.ndarray | None = None,
+        high: pd.Series | np.ndarray | None = None,
+        low: pd.Series | np.ndarray | None = None,
+        close: pd.Series | np.ndarray | None = None,
+        overlays: dict[str, pd.Series | np.ndarray] | None = None,
+        subplots: dict[str, pd.Series | np.ndarray] | None = None,
+        trades: pd.Series | np.ndarray | list | None = None,
     ):
+        """Validate the supplied series and store the normalized arrays for fast slicing."""
         # Validate input and get normalized arrays
         validated = validate_input(index, open, high, low, close, overlays, subplots, trades)
-        
+
         # Store references
         self._index = validated["index"]
         self._open = validated["open"]
@@ -246,58 +250,94 @@ class DataManager:
         self._subplots = validated["subplots"]
         self._subplot_meta = validated["subplot_meta"]
         self._trades = validated["trades"]
-        
+
         self._length = len(self._index)
-    
+
     @property
-    def index(self) -> np.ndarray: return self._index
+    def index(self) -> np.ndarray:
+        """The normalized x-axis (index) array."""
+        return self._index
+
     @property
-    def open(self) -> Optional[np.ndarray]: return self._open
+    def open(self) -> np.ndarray | None:
+        """Opening prices, or ``None`` if not provided."""
+        return self._open
+
     @property
-    def high(self) -> Optional[np.ndarray]: return self._high
+    def high(self) -> np.ndarray | None:
+        """High prices, or ``None`` if not provided."""
+        return self._high
+
     @property
-    def low(self) -> Optional[np.ndarray]: return self._low
+    def low(self) -> np.ndarray | None:
+        """Low prices, or ``None`` if not provided."""
+        return self._low
+
     @property
-    def close(self) -> Optional[np.ndarray]: return self._close
+    def close(self) -> np.ndarray | None:
+        """Closing prices, or ``None`` if not provided."""
+        return self._close
+
     @property
-    def overlays(self) -> Dict[str, np.ndarray]: return self._overlays
+    def overlays(self) -> dict[str, np.ndarray]:
+        """Mapping of overlay names to their normalized arrays."""
+        return self._overlays
+
     @property
-    def subplots(self) -> Dict[str, np.ndarray]: return self._subplots
+    def subplots(self) -> dict[str, np.ndarray]:
+        """Mapping of subplot keys to their normalized arrays."""
+        return self._subplots
+
     @property
-    def subplot_meta(self) -> Dict[str, list]: return self._subplot_meta
+    def subplot_meta(self) -> dict[str, list]:
+        """Per-subplot rendering metadata (type, color, label)."""
+        return self._subplot_meta
+
     @property
-    def trades(self) -> Optional[np.ndarray]: return self._trades
+    def trades(self) -> np.ndarray | None:
+        """Trade marker array (+1/-1/0), or ``None`` if not provided."""
+        return self._trades
+
     @property
-    def length(self) -> int: return self._length
-    def __len__(self) -> int: return self._length
-    
+    def length(self) -> int:
+        """Number of data points held by this manager."""
+        return self._length
+
+    def __len__(self) -> int:
+        """Return the number of data points."""
+        return self._length
+
     def __repr__(self) -> str:
+        """Return a concise summary of the manager's contents."""
         parts = [f"{self._length} points"]
         if self._overlays:
             parts.append(f"{len(self._overlays)} overlays")
         if self._subplots:
             parts.append(f"{len(self._subplots)} subplots")
         return f"DataManager({', '.join(parts)})"
-    
+
     def get_chunk(
         self,
-        start_index: Optional[int] = None,
-        end_index: Optional[int] = None,
-    ) -> Dict[str, Any]:
+        start_index: int | None = None,
+        end_index: int | None = None,
+    ) -> dict[str, Any]:
+        """Return a JSON-serializable slice of the data between ``start_index`` and ``end_index``."""
         # Handle default values
-        if start_index is None: start_index = 0
-        if end_index is None: end_index = self._length
-        
+        if start_index is None:
+            start_index = 0
+        if end_index is None:
+            end_index = self._length
+
         # Clamp indices
         start_index = max(0, min(start_index, self._length))
         end_index = max(start_index, min(end_index, self._length))
-        
+
         # Slice index array
         index_slice = self._index[start_index:end_index]
-        
+
         # Convert datetime types to Unix timestamps (milliseconds) for JavaScript
         if np.issubdtype(index_slice.dtype, np.datetime64):
-            index_list = (index_slice.astype('datetime64[ms]').astype(np.int64)).tolist()
+            index_list = (index_slice.astype("datetime64[ms]").astype(np.int64)).tolist()
         elif len(index_slice) > 0:
             first_elem = index_slice[0]
             if isinstance(first_elem, (pd.Timestamp, pd.Period)):
@@ -309,7 +349,7 @@ class DataManager:
                 index_list = index_slice.tolist()
         else:
             index_list = index_slice.tolist()
-        
+
         # Helper for slicing optional arrays
         def slice_opt(arr):
             return arr[start_index:end_index].tolist() if arr is not None else None
@@ -324,14 +364,14 @@ class DataManager:
             "subplots": {},
             "trades": slice_opt(self._trades),
         }
-        
+
         for name, data in self._overlays.items():
             result["overlays"][name] = data[start_index:end_index].tolist()
-        
+
         for name, data in self._subplots.items():
             result["subplots"][name] = data[start_index:end_index].tolist()
-        
+
         if self._subplot_meta:
             result["subplot_meta"] = self._subplot_meta
-        
+
         return result

--- a/src/pycharting/data/ingestion.py
+++ b/src/pycharting/data/ingestion.py
@@ -62,6 +62,7 @@ def validate_input(
 
     # Helper function to convert to numpy array
     def to_array(data: pd.Series | np.ndarray | list | None, name: str) -> np.ndarray | None:
+        """Convert ``data`` to a length-validated numpy array, or ``None`` if not provided."""
         if data is None:
             return None
         if isinstance(data, pd.Series):
@@ -352,6 +353,7 @@ class DataManager:
 
         # Helper for slicing optional arrays
         def slice_opt(arr):
+            """Return the requested slice of ``arr`` as a list, or ``None`` if ``arr`` is ``None``."""
             return arr[start_index:end_index].tolist() if arr is not None else None
 
         result = {

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi.testclient import TestClient
+
 from pycharting.core.server import create_app
 
 
@@ -10,20 +11,21 @@ def client():
     """Create test client."""
     # Clear session state before each test
     from pycharting.api.routes import _data_managers
+
     _data_managers.clear()
-    
+
     app = create_app()
     return TestClient(app)
 
 
 class TestAPIStatus:
     """Tests for API status endpoint."""
-    
+
     def test_api_status(self, client):
         """Test API status endpoint."""
         response = client.get("/api/status")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["status"] == "healthy"
         assert "active_sessions" in data
@@ -32,22 +34,22 @@ class TestAPIStatus:
 
 class TestDataInitialization:
     """Tests for data initialization endpoint."""
-    
+
     def test_init_default_session(self, client):
         """Test initializing default session."""
         response = client.post("/api/data/init")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["session_id"] == "default"
         assert data["status"] == "initialized"
         assert data["data_points"] == 1000
-    
+
     def test_init_custom_session(self, client):
         """Test initializing custom session."""
         response = client.post("/api/data/init?session_id=test")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["session_id"] == "test"
         assert data["status"] == "initialized"
@@ -55,7 +57,7 @@ class TestDataInitialization:
 
 class TestDataFetching:
     """Tests for data fetching endpoint."""
-    
+
     def test_get_data_without_session(self, client):
         """Test getting data without initializing session."""
         response = client.get("/api/data")
@@ -64,16 +66,16 @@ class TestDataFetching:
         # Check for error message in either 'detail' or 'error' key
         error_msg = response_json.get("detail") or response_json.get("error", "")
         assert "not found" in error_msg.lower()
-    
+
     def test_get_data_with_session(self, client):
         """Test getting data after initialization."""
         # Initialize session
         client.post("/api/data/init")
-        
+
         # Fetch data
         response = client.get("/api/data?start_index=0&end_index=100")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert "index" in data
         assert "open" in data
@@ -81,82 +83,82 @@ class TestDataFetching:
         assert "low" in data
         assert "close" in data
         assert len(data["index"]) == 100
-    
+
     def test_get_data_full_range(self, client):
         """Test getting all data."""
         client.post("/api/data/init")
-        
+
         response = client.get("/api/data")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["total_length"] == 1000
         assert len(data["index"]) == 1000
-    
+
     def test_get_data_partial_range(self, client):
         """Test getting partial data range."""
         client.post("/api/data/init")
-        
+
         response = client.get("/api/data?start_index=500&end_index=600")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["start_index"] == 500
         assert data["end_index"] == 600
         assert len(data["index"]) == 100
-    
+
     def test_get_data_with_custom_session(self, client):
         """Test getting data from custom session."""
         client.post("/api/data/init?session_id=custom")
-        
+
         response = client.get("/api/data?session_id=custom&start_index=0&end_index=50")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert len(data["index"]) == 50
 
 
 class TestSessionManagement:
     """Tests for session management endpoints."""
-    
+
     def test_list_sessions_empty(self, client):
         """Test listing sessions when none exist."""
         response = client.get("/api/sessions")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["count"] == 0
         assert len(data["sessions"]) == 0
-    
+
     def test_list_sessions_with_data(self, client):
         """Test listing sessions after initialization."""
         client.post("/api/data/init")
         client.post("/api/data/init?session_id=test")
-        
+
         response = client.get("/api/sessions")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["count"] == 2
         assert len(data["sessions"]) == 2
-    
+
     def test_delete_session(self, client):
         """Test deleting a session."""
         client.post("/api/data/init?session_id=to_delete")
-        
+
         # Verify session exists
         response = client.get("/api/sessions")
         assert response.json()["count"] == 1
-        
+
         # Delete session
         response = client.delete("/api/sessions/to_delete")
         assert response.status_code == 200
         assert response.json()["status"] == "deleted"
-        
+
         # Verify session is gone
         response = client.get("/api/sessions")
         assert response.json()["count"] == 0
-    
+
     def test_delete_nonexistent_session(self, client):
         """Test deleting non-existent session."""
         response = client.delete("/api/sessions/nonexistent")
@@ -165,21 +167,21 @@ class TestSessionManagement:
 
 class TestDataValidation:
     """Tests for data validation."""
-    
+
     def test_negative_start_index(self, client):
         """Test that negative start index is rejected."""
         client.post("/api/data/init")
-        
+
         response = client.get("/api/data?start_index=-1")
         assert response.status_code == 422  # Validation error
-    
+
     def test_overlays_and_subplots(self, client):
         """Test that response includes overlay/subplot fields."""
         client.post("/api/data/init")
-        
+
         response = client.get("/api/data?start_index=0&end_index=10")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert "overlays" in data
         assert "subplots" in data
@@ -189,43 +191,43 @@ class TestDataValidation:
 
 class TestAPIIntegration:
     """Integration tests for API."""
-    
+
     def test_full_workflow(self, client):
         """Test complete workflow: init -> fetch -> delete."""
         # Initialize
         response = client.post("/api/data/init?session_id=workflow")
         assert response.status_code == 200
-        
+
         # Fetch data
         response = client.get("/api/data?session_id=workflow&start_index=0&end_index=100")
         assert response.status_code == 200
         assert len(response.json()["index"]) == 100
-        
+
         # List sessions
         response = client.get("/api/sessions")
         assert response.status_code == 200
         assert response.json()["count"] == 1
-        
+
         # Delete session
         response = client.delete("/api/sessions/workflow")
         assert response.status_code == 200
-        
+
         # Verify data is inaccessible
         response = client.get("/api/data?session_id=workflow")
         assert response.status_code == 404
-    
+
     def test_multiple_sessions(self, client):
         """Test working with multiple sessions simultaneously."""
         # Create multiple sessions
         for i in range(3):
             response = client.post(f"/api/data/init?session_id=session{i}")
             assert response.status_code == 200
-        
+
         # Fetch from each
         for i in range(3):
             response = client.get(f"/api/data?session_id=session{i}&start_index=0&end_index=10")
             assert response.status_code == 200
-        
+
         # Verify all exist
         response = client.get("/api/sessions")
         assert response.json()["count"] == 3
@@ -235,8 +237,11 @@ class TestErrorPaths:
     """Tests for internal error handling in routes."""
 
     def test_get_data_internal_error_returns_500(self, client):
+        """Verify the data endpoint returns 500 when get_chunk raises an error."""
         from unittest.mock import MagicMock
+
         from pycharting.api.routes import _data_managers
+
         mock_dm = MagicMock()
         mock_dm.get_chunk.side_effect = RuntimeError("disk failure")
         _data_managers["err"] = mock_dm
@@ -247,7 +252,9 @@ class TestErrorPaths:
             _data_managers.pop("err", None)
 
     def test_initialize_data_internal_error_returns_500(self, client):
+        """Verify the data init endpoint returns 500 when DataManager raises."""
         from unittest.mock import patch
+
         with patch("pycharting.data.ingestion.DataManager", side_effect=RuntimeError("boom")):
             response = client.post("/api/data/init?session_id=err2")
             assert response.status_code == 500

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -1,14 +1,15 @@
 """Tests for data ingestion and validation module."""
 
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
+
 from pycharting.data.ingestion import DataManager, DataValidationError, validate_input
 
 
 class TestValidateInput:
     """Tests for the validate_input function."""
-    
+
     def test_valid_pandas_input(self):
         """Test validation with valid Pandas Series input."""
         index = pd.date_range("2024-01-01", periods=5)
@@ -16,14 +17,14 @@ class TestValidateInput:
         high = pd.Series([105, 106, 105, 107, 106])
         low = pd.Series([99, 100, 99, 101, 100])
         close = pd.Series([104, 103, 104, 105, 104])
-        
+
         result = validate_input(index, open_data, high, low, close)
-        
+
         assert isinstance(result["index"], np.ndarray)
         assert isinstance(result["open"], np.ndarray)
         assert len(result["index"]) == 5
         assert np.array_equal(result["open"], [100, 102, 101, 103, 102])
-    
+
     def test_valid_numpy_input(self):
         """Test validation with valid NumPy array input."""
         index = np.arange(5)
@@ -31,13 +32,13 @@ class TestValidateInput:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         result = validate_input(index, open_data, high, low, close)
-        
+
         assert isinstance(result["index"], np.ndarray)
         assert len(result["index"]) == 5
         assert np.array_equal(result["close"], [104, 103, 104, 105, 104])
-    
+
     def test_with_overlays(self):
         """Test validation with overlay data."""
         index = np.arange(5)
@@ -49,14 +50,14 @@ class TestValidateInput:
             "SMA20": np.array([101, 102, 102, 103, 103]),
             "EMA10": np.array([100, 101, 101, 102, 102]),
         }
-        
+
         result = validate_input(index, open_data, high, low, close, overlays=overlays)
-        
+
         assert len(result["overlays"]) == 2
         assert "SMA20" in result["overlays"]
         assert "EMA10" in result["overlays"]
         assert np.array_equal(result["overlays"]["SMA20"], [101, 102, 102, 103, 103])
-    
+
     def test_with_subplots(self):
         """Test validation with subplot data."""
         index = np.arange(5)
@@ -68,13 +69,13 @@ class TestValidateInput:
             "Volume": np.array([1000, 1200, 1100, 1300, 1150]),
             "RSI": np.array([55, 58, 52, 60, 57]),
         }
-        
+
         result = validate_input(index, open_data, high, low, close, subplots=subplots)
-        
+
         assert len(result["subplots"]) == 2
         assert "Volume" in result["subplots"]
         assert "RSI" in result["subplots"]
-    
+
     def test_invalid_index_type(self):
         """Test that invalid index type raises error."""
         index = [1, 2, 3, 4, 5]  # List instead of Index or ndarray
@@ -82,10 +83,10 @@ class TestValidateInput:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         with pytest.raises(DataValidationError, match="Index must be"):
             validate_input(index, open_data, high, low, close)
-    
+
     def test_length_mismatch(self):
         """Test that mismatched lengths raise error."""
         index = np.arange(5)
@@ -93,10 +94,10 @@ class TestValidateInput:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         with pytest.raises(DataValidationError, match="does not match index length"):
             validate_input(index, open_data, high, low, close)
-    
+
     def test_ohlc_constraint_high_violation(self):
         """Test that High < max(Open, Close) raises error."""
         index = np.arange(5)
@@ -104,10 +105,10 @@ class TestValidateInput:
         high = np.array([99, 106, 105, 107, 106])  # First high < open
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         with pytest.raises(DataValidationError, match="High must be >= max"):
             validate_input(index, open_data, high, low, close)
-    
+
     def test_ohlc_constraint_low_violation(self):
         """Test that Low > min(Open, Close) raises error."""
         index = np.arange(5)
@@ -115,10 +116,10 @@ class TestValidateInput:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([101, 100, 99, 101, 100])  # First low > open
         close = np.array([104, 103, 104, 105, 104])
-        
+
         with pytest.raises(DataValidationError, match="Low must be <= min"):
             validate_input(index, open_data, high, low, close)
-    
+
     def test_overlay_length_mismatch(self):
         """Test that mismatched overlay length raises error."""
         index = np.arange(5)
@@ -127,14 +128,14 @@ class TestValidateInput:
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
         overlays = {"SMA20": np.array([101, 102, 102])}  # Length 3
-        
-        with pytest.raises(DataValidationError, match="Overlay.*does not match"):
+
+        with pytest.raises(DataValidationError, match=r"Overlay.*does not match"):
             validate_input(index, open_data, high, low, close, overlays=overlays)
 
 
 class TestDataManager:
     """Tests for the DataManager class."""
-    
+
     def test_init_with_numpy_arrays(self):
         """Test initialization with NumPy arrays."""
         index = np.arange(5)
@@ -142,14 +143,14 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         assert len(dm) == 5
         assert dm.length == 5
         assert isinstance(dm.open, np.ndarray)
         assert np.array_equal(dm.open, open_data)
-    
+
     def test_init_with_pandas_series(self):
         """Test initialization with Pandas Series."""
         index = pd.date_range("2024-01-01", periods=5)
@@ -157,13 +158,13 @@ class TestDataManager:
         high = pd.Series([105, 106, 105, 107, 106])
         low = pd.Series([99, 100, 99, 101, 100])
         close = pd.Series([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         assert len(dm) == 5
         assert isinstance(dm.close, np.ndarray)
         assert dm.close[0] == 104
-    
+
     def test_properties(self):
         """Test all property accessors."""
         index = np.arange(3)
@@ -171,9 +172,9 @@ class TestDataManager:
         high = np.array([105, 106, 105])
         low = np.array([99, 100, 99])
         close = np.array([104, 103, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         assert np.array_equal(dm.index, index)
         assert np.array_equal(dm.open, open_data)
         assert np.array_equal(dm.high, high)
@@ -181,7 +182,7 @@ class TestDataManager:
         assert np.array_equal(dm.close, close)
         assert isinstance(dm.overlays, dict)
         assert isinstance(dm.subplots, dict)
-    
+
     def test_with_overlays_and_subplots(self):
         """Test initialization with overlays and subplots."""
         index = np.arange(5)
@@ -191,15 +192,15 @@ class TestDataManager:
         close = np.array([104, 103, 104, 105, 104])
         overlays = {"SMA20": np.array([101, 102, 102, 103, 103])}
         subplots = {"Volume": np.array([1000, 1200, 1100, 1300, 1150])}
-        
+
         dm = DataManager(index, open_data, high, low, close, overlays, subplots)
-        
+
         assert len(dm.overlays) == 1
         assert "SMA20" in dm.overlays
         assert len(dm.subplots) == 1
         assert "Volume" in dm.subplots
         assert np.array_equal(dm.overlays["SMA20"], [101, 102, 102, 103, 103])
-    
+
     def test_invalid_data_raises_error(self):
         """Test that invalid OHLC data raises DataValidationError."""
         index = np.arange(5)
@@ -207,10 +208,10 @@ class TestDataManager:
         high = np.array([99, 106, 105, 107, 106])  # First high < open
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         with pytest.raises(DataValidationError):
             DataManager(index, open_data, high, low, close)
-    
+
     def test_repr(self):
         """Test string representation."""
         index = np.arange(5)
@@ -218,13 +219,13 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
         repr_str = repr(dm)
-        
+
         assert "DataManager" in repr_str
         assert "5 points" in repr_str
-    
+
     def test_repr_with_overlays(self):
         """Test string representation with overlays."""
         index = np.arange(3)
@@ -233,12 +234,12 @@ class TestDataManager:
         low = np.array([99, 100, 99])
         close = np.array([104, 103, 104])
         overlays = {"SMA20": np.array([101, 102, 102])}
-        
+
         dm = DataManager(index, open_data, high, low, close, overlays=overlays)
         repr_str = repr(dm)
-        
+
         assert "1 overlays" in repr_str
-    
+
     def test_no_data_duplication(self):
         """Test that data is not duplicated unnecessarily."""
         index = np.arange(5)
@@ -246,13 +247,13 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Verify arrays are stored (conversion happened but data is referenced)
         assert dm.open.dtype == open_data.dtype
         assert len(dm.open) == len(open_data)
-    
+
     def test_timestamp_conversion_to_milliseconds(self):
         """Test that DatetimeIndex is converted to Unix timestamps in milliseconds."""
         # Create a DatetimeIndex with known timestamps
@@ -261,24 +262,24 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Get chunk should return timestamps in milliseconds
         chunk = dm.get_chunk(0, 5)
-        
+
         # Verify that index is a list of integers (Unix timestamps in milliseconds)
         assert isinstance(chunk["index"], list)
         assert all(isinstance(x, int) for x in chunk["index"])
-        
+
         # Verify timestamps are in the correct range (milliseconds since epoch)
         # For 2024-01-01, timestamps should be around 1704067200000 (ms)
         expected_first_ts = int(pd.Timestamp("2024-01-01").timestamp() * 1000)
         assert chunk["index"][0] == expected_first_ts
-        
+
         # Verify timestamps are 1 hour apart (3600000 ms)
         assert chunk["index"][1] - chunk["index"][0] == 3600000
-    
+
     def test_numeric_index_unchanged(self):
         """Test that numeric indices are not converted to timestamps."""
         # Use plain numeric index
@@ -287,15 +288,15 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Get chunk should return plain numeric indices
         chunk = dm.get_chunk(0, 5)
-        
+
         # Verify that index is unchanged
         assert chunk["index"] == [0, 1, 2, 3, 4]
-    
+
     def test_unix_timestamp_index_unchanged(self):
         """Test that raw Unix timestamps (already in milliseconds) pass through unchanged."""
         # Use Unix timestamps in milliseconds (like JavaScript Date.now())
@@ -305,16 +306,16 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Get chunk should return timestamps unchanged
         chunk = dm.get_chunk(0, 5)
-        
+
         # Verify timestamps are preserved
         assert chunk["index"] == index.tolist()
         assert all(isinstance(x, int) for x in chunk["index"])
-    
+
     def test_timezone_aware_index(self):
         """Test that timezone-aware indices are correctly converted to milliseconds."""
         # Create a timezone-aware index (UTC)
@@ -323,16 +324,16 @@ class TestDataManager:
         high = np.array([105, 106, 105, 107, 106])
         low = np.array([99, 100, 99, 101, 100])
         close = np.array([104, 103, 104, 105, 104])
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Get chunk should return valid integer timestamps, NOT Timestamps objects
         chunk = dm.get_chunk(0, 5)
-        
+
         # Verify conversion
         assert isinstance(chunk["index"], list)
         assert all(isinstance(x, int) for x in chunk["index"])
-        
+
         # Expected timestamp (1704067200000 for 2024-01-01 UTC)
         expected_ts = 1704067200000
         assert chunk["index"][0] == expected_ts
@@ -342,6 +343,7 @@ class TestValidateInputEdgeCases:
     """Tests for edge cases in validate_input."""
 
     def test_to_array_none_returns_none(self):
+        """Verify omitted data series default to None in the result."""
         index = np.arange(5)
         close = np.array([100, 102, 103, 104, 105])
         result = validate_input(index, close=close)
@@ -350,6 +352,7 @@ class TestValidateInputEdgeCases:
         assert result["low"] is None
 
     def test_to_array_list_input(self):
+        """Verify plain Python lists are converted to numpy arrays."""
         index = np.arange(5)
         result = validate_input(
             index,
@@ -362,16 +365,19 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["open"], [100, 102, 101, 103, 102])
 
     def test_to_array_invalid_type_raises(self):
+        """Verify passing a non-array-like type as a data series raises an error."""
         index = np.arange(5)
         with pytest.raises(DataValidationError):
             validate_input(index, "invalid", np.zeros(5), np.zeros(5), np.zeros(5))
 
     def test_no_series_raises(self):
+        """Verify calling validate_input with no data series raises an error."""
         index = np.arange(5)
         with pytest.raises(DataValidationError, match="At least one data series"):
             validate_input(index)
 
     def test_single_series_mode(self):
+        """Verify passing only close yields a single-series result with other fields None."""
         index = np.arange(5)
         close = np.array([100, 102, 103, 104, 105])
         result = validate_input(index, close=close)
@@ -381,6 +387,7 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["close"], close)
 
     def test_open_fallback_when_none(self):
+        """Verify open falls back to close when open is None."""
         index = np.arange(5)
         high = np.array([106, 108, 107, 109, 108])
         low = np.array([99, 100, 99, 101, 100])
@@ -389,6 +396,7 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["open"], close)
 
     def test_close_fallback_when_none(self):
+        """Verify close falls back to open when close is None."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])
@@ -397,6 +405,7 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["close"], open_data)
 
     def test_high_auto_computed(self):
+        """Verify high is auto-computed as the element-wise maximum of open and close."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         close = np.array([104, 101, 104, 102, 105])
@@ -404,6 +413,7 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["high"], np.maximum(open_data, close))
 
     def test_low_auto_computed(self):
+        """Verify low is auto-computed as the element-wise minimum of open and close."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         close = np.array([104, 101, 104, 102, 105])
@@ -411,6 +421,7 @@ class TestValidateInputEdgeCases:
         assert np.array_equal(result["low"], np.minimum(open_data, close))
 
     def test_trades_valid(self):
+        """Verify a valid trades array is accepted and cast to int8."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])
@@ -422,12 +433,14 @@ class TestValidateInputEdgeCases:
         assert result["trades"].dtype == np.int8
 
     def test_trades_invalid_values_raise(self):
+        """Verify a trades array with values outside -1, 0, 1 raises an error."""
         index = np.arange(5)
         close = np.array([100, 102, 103, 104, 105])
         with pytest.raises(DataValidationError, match="Trades array must contain only"):
             validate_input(index, close=close, trades=np.array([1, 2, -1, 0, 1]))
 
     def test_subplot_multi_series_format(self):
+        """Verify a list of subplot series is split into indexed keys with metadata."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])
@@ -445,6 +458,7 @@ class TestValidateInputEdgeCases:
         assert len(result["subplot_meta"]["MACD"]) == 2
 
     def test_subplot_dict_format(self):
+        """Verify a single-dict subplot definition is parsed with its type metadata."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])
@@ -460,6 +474,7 @@ class TestDataManagerEdgeCases:
     """Tests for DataManager repr and chunk edge cases."""
 
     def test_repr_with_subplots(self):
+        """Verify the DataManager repr reports the number of subplots."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])
@@ -470,6 +485,7 @@ class TestDataManagerEdgeCases:
         assert "1 subplots" in repr(dm)
 
     def test_get_chunk_includes_subplot_meta(self):
+        """Verify get_chunk includes subplot_meta with subplot keys in the result."""
         index = np.arange(5)
         open_data = np.array([100, 102, 101, 103, 102])
         high = np.array([105, 106, 105, 107, 106])

--- a/tests/test_data_slicing.py
+++ b/tests/test_data_slicing.py
@@ -1,14 +1,15 @@
 """Tests for data slicing functionality."""
 
-import pytest
-import numpy as np
 import time
+
+import numpy as np
+
 from pycharting.data.ingestion import DataManager
 
 
 class TestGetChunk:
     """Tests for the get_chunk method."""
-    
+
     def test_basic_chunk(self):
         """Test basic chunk retrieval."""
         index = np.arange(10)
@@ -16,15 +17,15 @@ class TestGetChunk:
         high = np.array([105, 106, 105, 107, 106, 108, 107, 109, 108, 110])
         low = np.array([99, 100, 99, 101, 100, 102, 101, 103, 102, 104])
         close = np.array([104, 103, 104, 105, 104, 106, 105, 107, 106, 108])
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(0, 5)
-        
+
         assert len(chunk["index"]) == 5
         assert chunk["index"] == [0, 1, 2, 3, 4]
         assert chunk["open"] == [100, 102, 101, 103, 102]
         assert chunk["close"] == [104, 103, 104, 105, 104]
-    
+
     def test_middle_chunk(self):
         """Test retrieving a chunk from the middle of data."""
         index = np.arange(10)
@@ -32,14 +33,14 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(3, 7)
-        
+
         assert len(chunk["index"]) == 4
         assert chunk["index"] == [3, 4, 5, 6]
         assert chunk["open"] == [103, 104, 105, 106]
-    
+
     def test_chunk_with_none_start(self):
         """Test chunk with None start index (from beginning)."""
         index = np.arange(10)
@@ -47,13 +48,13 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(None, 5)
-        
+
         assert len(chunk["index"]) == 5
         assert chunk["index"] == [0, 1, 2, 3, 4]
-    
+
     def test_chunk_with_none_end(self):
         """Test chunk with None end index (to end)."""
         index = np.arange(10)
@@ -61,14 +62,14 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(7, None)
-        
+
         assert len(chunk["index"]) == 3
         assert chunk["index"] == [7, 8, 9]
         assert chunk["open"] == [107, 108, 109]
-    
+
     def test_chunk_with_both_none(self):
         """Test chunk with both indices None (entire dataset)."""
         index = np.arange(5)
@@ -76,13 +77,13 @@ class TestGetChunk:
         high = np.arange(105, 110)
         low = np.arange(95, 100)
         close = np.arange(102, 107)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(None, None)
-        
+
         assert len(chunk["index"]) == 5
         assert chunk["index"] == [0, 1, 2, 3, 4]
-    
+
     def test_empty_chunk(self):
         """Test empty chunk when start equals end."""
         index = np.arange(10)
@@ -90,13 +91,13 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(5, 5)
-        
+
         assert len(chunk["index"]) == 0
         assert chunk["open"] == []
-    
+
     def test_out_of_bounds_positive(self):
         """Test chunk with indices beyond data length."""
         index = np.arange(10)
@@ -104,13 +105,13 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(8, 20)  # End beyond length
-        
+
         assert len(chunk["index"]) == 2  # Clamped to available data
         assert chunk["index"] == [8, 9]
-    
+
     def test_out_of_bounds_negative(self):
         """Test chunk with negative start index."""
         index = np.arange(10)
@@ -118,14 +119,14 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(-5, 5)  # Negative start
-        
+
         # Negative indices should be clamped to 0
         assert len(chunk["index"]) == 5
         assert chunk["index"] == [0, 1, 2, 3, 4]
-    
+
     def test_inverted_indices(self):
         """Test chunk with start > end (should return empty)."""
         index = np.arange(10)
@@ -133,13 +134,13 @@ class TestGetChunk:
         high = np.arange(105, 115)
         low = np.arange(95, 105)
         close = np.arange(102, 112)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(7, 3)  # Start > end
-        
+
         # Should clamp end_index to be at least start_index
         assert len(chunk["index"]) == 0
-    
+
     def test_chunk_with_overlays(self):
         """Test chunk includes overlay data."""
         index = np.arange(10)
@@ -151,16 +152,16 @@ class TestGetChunk:
             "SMA20": np.arange(101, 111),
             "EMA10": np.arange(100.5, 110.5),
         }
-        
+
         dm = DataManager(index, open_data, high, low, close, overlays=overlays)
         chunk = dm.get_chunk(2, 7)
-        
+
         assert len(chunk["overlays"]) == 2
         assert "SMA20" in chunk["overlays"]
         assert "EMA10" in chunk["overlays"]
         assert chunk["overlays"]["SMA20"] == [103, 104, 105, 106, 107]
         assert len(chunk["overlays"]["EMA10"]) == 5
-    
+
     def test_chunk_with_subplots(self):
         """Test chunk includes subplot data."""
         index = np.arange(10)
@@ -172,38 +173,38 @@ class TestGetChunk:
             "Volume": np.arange(1000, 1010) * 100,
             "RSI": np.arange(50, 60),
         }
-        
+
         dm = DataManager(index, open_data, high, low, close, subplots=subplots)
         chunk = dm.get_chunk(1, 6)
-        
+
         assert len(chunk["subplots"]) == 2
         assert "Volume" in chunk["subplots"]
         assert "RSI" in chunk["subplots"]
         assert len(chunk["subplots"]["Volume"]) == 5
         assert chunk["subplots"]["RSI"] == [51, 52, 53, 54, 55]
-    
+
     def test_chunk_json_serializable(self):
         """Test that chunk output is JSON serializable."""
         import json
-        
+
         index = np.arange(5)
         open_data = np.arange(100, 105)
         high = np.arange(105, 110)
         low = np.arange(95, 100)
         close = np.arange(102, 107)
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(0, 5)
-        
+
         # Should not raise any exception
         json_str = json.dumps(chunk)
         assert isinstance(json_str, str)
-        
+
         # Verify round-trip
         recovered = json.loads(json_str)
         assert recovered["index"] == chunk["index"]
         assert recovered["open"] == chunk["open"]
-    
+
     def test_performance_large_dataset(self):
         """Test performance with large dataset (100k points)."""
         n = 100000
@@ -212,18 +213,18 @@ class TestGetChunk:
         high = open_data + np.random.uniform(0, 10, n)
         low = open_data - np.random.uniform(0, 10, n)
         close = np.random.uniform(low, high)
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Measure slicing performance
         start_time = time.time()
         chunk = dm.get_chunk(10000, 20000)  # 10k points
         elapsed_ms = (time.time() - start_time) * 1000
-        
+
         # Should be well under 100ms for 10k points
         assert elapsed_ms < 100, f"Slicing took {elapsed_ms:.2f}ms, expected <100ms"
         assert len(chunk["index"]) == 10000
-    
+
     def test_performance_small_slice_large_dataset(self):
         """Test performance of small slice from large dataset."""
         n = 100000
@@ -232,18 +233,18 @@ class TestGetChunk:
         high = open_data + np.random.uniform(0, 10, n)
         low = open_data - np.random.uniform(0, 10, n)
         close = np.random.uniform(low, high)
-        
+
         dm = DataManager(index, open_data, high, low, close)
-        
+
         # Small slice should be extremely fast
         start_time = time.time()
         chunk = dm.get_chunk(50000, 50100)  # Just 100 points
         elapsed_ms = (time.time() - start_time) * 1000
-        
+
         # Should be very fast (< 10ms)
         assert elapsed_ms < 10, f"Small slice took {elapsed_ms:.2f}ms, expected <10ms"
         assert len(chunk["index"]) == 100
-    
+
     def test_chunk_data_types(self):
         """Test that chunk returns proper Python types (not numpy)."""
         index = np.arange(5)
@@ -251,16 +252,16 @@ class TestGetChunk:
         high = np.array([105.1, 106.2, 105.4, 107.3, 106.9])
         low = np.array([99.2, 100.1, 99.5, 101.3, 100.7])
         close = np.array([104.3, 103.8, 104.2, 105.6, 104.9])
-        
+
         dm = DataManager(index, open_data, high, low, close)
         chunk = dm.get_chunk(0, 3)
-        
+
         # All values should be Python lists, not numpy arrays
         assert isinstance(chunk["index"], list)
         assert isinstance(chunk["open"], list)
         assert isinstance(chunk["high"], list)
         assert isinstance(chunk["low"], list)
         assert isinstance(chunk["close"], list)
-        
+
         # Individual values should be Python numbers
         assert isinstance(chunk["open"][0], (int, float))

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,11 +1,10 @@
 """Basic import tests for PyCharting package."""
 
-import pytest
-
 
 def test_package_import():
     """Test that the main package can be imported."""
     import pycharting
+
     assert isinstance(pycharting.__version__, str)
     assert pycharting.__version__
 
@@ -13,35 +12,39 @@ def test_package_import():
 def test_core_import():
     """Test that core module can be imported."""
     from pycharting import core
+
     assert core is not None
 
 
 def test_data_import():
     """Test that data module can be imported."""
     from pycharting import data
+
     assert data is not None
 
 
 def test_api_import():
     """Test that api module can be imported."""
     from pycharting import api
+
     assert api is not None
 
 
 def test_web_import():
     """Test that web module can be imported."""
     from pycharting import web
+
     assert web is not None
 
 
 def test_dependencies_available():
     """Test that core dependencies are available."""
-    import pandas
-    import numpy
     import fastapi
+    import numpy as np
+    import pandas as pd
     import uvicorn
-    
-    assert pandas is not None
-    assert numpy is not None
+
+    assert pd is not None
+    assert np is not None
     assert fastapi is not None
     assert uvicorn is not None

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,11 +1,11 @@
 """Tests for Python API interface."""
 
-import pytest
-import numpy as np
-import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-from pycharting.api.interface import plot, stop_server, get_server_status, _active_server, _repr_html_
+import numpy as np
+import pytest
+
+from pycharting.api.interface import _active_server, _repr_html_, get_server_status, plot, stop_server
 from pycharting.api.routes import _data_managers
 
 
@@ -13,16 +13,16 @@ from pycharting.api.routes import _data_managers
 def cleanup_globals():
     """Clean up global state between tests."""
     global _active_server
-    
+
     # Stop any active server before test
     if _active_server and _active_server.is_running:
         _active_server.stop_server()
-    
+
     # Clear data managers
     _data_managers.clear()
-    
+
     yield
-    
+
     # Clean up after test
     if _active_server and _active_server.is_running:
         _active_server.stop_server()
@@ -31,7 +31,7 @@ def cleanup_globals():
 
 class TestPlotFunction:
     """Tests for the main plot() function."""
-    
+
     def test_plot_basic_usage(self):
         """Test basic plot creation with minimal arguments."""
         # Generate sample data
@@ -41,37 +41,30 @@ class TestPlotFunction:
         open_data = close + np.random.randn(n) * 0.5
         high = np.maximum(open_data, close) + np.abs(np.random.randn(n))
         low = np.minimum(open_data, close) - np.abs(np.random.randn(n))
-        
+
         # Create chart without opening browser
-        result = plot(
-            index, open_data, high, low, close,
-            open_browser=False,
-            block=False
-        )
-        
-        assert result['status'] == 'success'
-        assert 'url' in result
-        assert result['data_points'] == n
-        assert result['server_running'] is True
-        assert 'default' in result['session_id']
-    
+        result = plot(index, open_data, high, low, close, open_browser=False, block=False)
+
+        assert result["status"] == "success"
+        assert "url" in result
+        assert result["data_points"] == n
+        assert result["server_running"] is True
+        assert "default" in result["session_id"]
+
     def test_plot_with_custom_session(self):
         """Test plot with custom session ID."""
         n = 50
         index = np.arange(n)
         data = np.random.randn(n) + 100
-        
+
         result = plot(
-            index, data, data + 1, data - 1, data,
-            session_id='custom_session',
-            open_browser=False,
-            block=False
+            index, data, data + 1, data - 1, data, session_id="custom_session", open_browser=False, block=False
         )
-        
-        assert result['status'] == 'success'
-        assert result['session_id'] == 'custom_session'
-        assert 'custom_session' in _data_managers
-    
+
+        assert result["status"] == "success"
+        assert result["session_id"] == "custom_session"
+        assert "custom_session" in _data_managers
+
     def test_plot_with_overlays(self):
         """Test plot with overlay data."""
         n = 100
@@ -80,50 +73,35 @@ class TestPlotFunction:
         open_data = close + np.random.randn(n) * 0.5
         high = np.maximum(open_data, close) + np.abs(np.random.randn(n))
         low = np.minimum(open_data, close) - np.abs(np.random.randn(n))
-        
+
         # Add moving average overlay
-        ma = np.convolve(close, np.ones(10)/10, mode='same')
-        
-        result = plot(
-            index, open_data, high, low, close,
-            overlays={'MA10': ma},
-            open_browser=False,
-            block=False
-        )
-        
-        assert result['status'] == 'success'
+        ma = np.convolve(close, np.ones(10) / 10, mode="same")
+
+        result = plot(index, open_data, high, low, close, overlays={"MA10": ma}, open_browser=False, block=False)
+
+        assert result["status"] == "success"
         # Check that data manager has overlay
-        dm = _data_managers['default']
-        assert 'MA10' in dm.overlays
-    
+        dm = _data_managers["default"]
+        assert "MA10" in dm.overlays
+
     def test_plot_reuses_server(self):
         """Test that multiple plots reuse the same server."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
+
         # First plot
-        result1 = plot(
-            index, data, data + 1, data - 1, data,
-            session_id='session1',
-            open_browser=False,
-            block=False
-        )
-        
-        first_server_url = result1['server_url']
-        
+        result1 = plot(index, data, data + 1, data - 1, data, session_id="session1", open_browser=False, block=False)
+
+        first_server_url = result1["server_url"]
+
         # Second plot should reuse server
-        result2 = plot(
-            index, data, data + 1, data - 1, data,
-            session_id='session2',
-            open_browser=False,
-            block=False
-        )
-        
-        assert result2['server_url'] == first_server_url
-        assert result1['status'] == 'success'
-        assert result2['status'] == 'success'
-    
+        result2 = plot(index, data, data + 1, data - 1, data, session_id="session2", open_browser=False, block=False)
+
+        assert result2["server_url"] == first_server_url
+        assert result1["status"] == "success"
+        assert result2["status"] == "success"
+
     def test_plot_with_invalid_data(self):
         """Test plot with invalid data returns error."""
         # Try with mismatched array lengths
@@ -134,67 +112,59 @@ class TestPlotFunction:
             np.random.randn(10),
             np.random.randn(5),  # Wrong length!
             open_browser=False,
-            block=False
+            block=False,
         )
-        
-        assert result['status'] == 'error'
-        assert 'error' in result
-    
-    @patch('webbrowser.open')
+
+        assert result["status"] == "error"
+        assert "error" in result
+
+    @patch("webbrowser.open")
     def test_plot_opens_browser(self, mock_browser):
         """Test that plot opens browser when requested."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
-        result = plot(
-            index, data, data + 1, data - 1, data,
-            open_browser=True,
-            block=False
-        )
-        
-        assert result['status'] == 'success'
+
+        result = plot(index, data, data + 1, data - 1, data, open_browser=True, block=False)
+
+        assert result["status"] == "success"
         # Check that browser.open was called
         mock_browser.assert_called_once()
         call_args = mock_browser.call_args[0][0]
-        assert 'http://' in call_args
-    
-    @patch('webbrowser.open', side_effect=Exception("Browser error"))
+        assert "http://" in call_args
+
+    @patch("webbrowser.open", side_effect=Exception("Browser error"))
     def test_plot_handles_browser_error(self, mock_browser):
         """Test that plot handles browser opening errors gracefully."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
+
         # Should still succeed even if browser fails
-        result = plot(
-            index, data, data + 1, data - 1, data,
-            open_browser=True,
-            block=False
-        )
-        
-        assert result['status'] == 'success'
-        assert result['server_running'] is True
+        result = plot(index, data, data + 1, data - 1, data, open_browser=True, block=False)
+
+        assert result["status"] == "success"
+        assert result["server_running"] is True
 
 
 class TestStopServer:
     """Tests for stop_server() function."""
-    
+
     def test_stop_server_when_running(self):
         """Test stopping an active server."""
         # Start a server first
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
+
         plot(index, data, data + 1, data - 1, data, open_browser=False, block=False)
-        
+
         # Now stop it
         stop_server()
-        
+
         status = get_server_status()
-        assert status['running'] is False
-    
+        assert status["running"] is False
+
     def test_stop_server_when_not_running(self):
         """Test stopping when no server is active."""
         # Should not raise an error
@@ -203,71 +173,62 @@ class TestStopServer:
 
 class TestGetServerStatus:
     """Tests for get_server_status() function."""
-    
+
     def test_status_when_no_server(self):
         """Test status when no server has been started."""
         status = get_server_status()
-        
-        assert status['running'] is False
+
+        assert status["running"] is False
         # server_info may exist from previous server, just check it's not running
-        assert status['active_sessions'] == 0
-    
+        assert status["active_sessions"] == 0
+
     def test_status_when_server_running(self):
         """Test status when server is active."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
+
         # Start server
         plot(index, data, data + 1, data - 1, data, open_browser=False, block=False)
-        
+
         status = get_server_status()
-        
-        assert status['running'] is True
-        assert status['server_info'] is not None
-        assert status['active_sessions'] >= 1
-        assert 'host' in status['server_info']
-        assert 'port' in status['server_info']
+
+        assert status["running"] is True
+        assert status["server_info"] is not None
+        assert status["active_sessions"] >= 1
+        assert "host" in status["server_info"]
+        assert "port" in status["server_info"]
 
 
 class TestDataTypes:
     """Tests for different data type inputs."""
-    
+
     def test_plot_with_numpy_arrays(self):
         """Test plot with NumPy arrays."""
         n = 50
         index = np.arange(n)
         close = np.random.randn(n) + 100
-        
-        result = plot(
-            index, close, close + 1, close - 1, close,
-            open_browser=False,
-            block=False
-        )
-        
-        assert result['status'] == 'success'
-    
+
+        result = plot(index, close, close + 1, close - 1, close, open_browser=False, block=False)
+
+        assert result["status"] == "success"
+
     def test_plot_with_lists(self):
         """Test plot with Python lists."""
         n = 50
         index = list(range(n))
         close = [100 + i * 0.1 for i in range(n)]
-        
+
         result = plot(
-            index, close, 
-            [c + 1 for c in close],
-            [c - 1 for c in close],
-            close,
-            open_browser=False,
-            block=False
+            index, close, [c + 1 for c in close], [c - 1 for c in close], close, open_browser=False, block=False
         )
-        
-        assert result['status'] == 'success'
+
+        assert result["status"] == "success"
 
 
 class TestIntegration:
     """Integration tests for complete workflows."""
-    
+
     def test_full_workflow(self):
         """Test complete workflow: plot -> check status -> stop."""
         # Generate data
@@ -277,55 +238,49 @@ class TestIntegration:
         open_data = close + np.random.randn(n) * 0.5
         high = np.maximum(open_data, close) + np.abs(np.random.randn(n))
         low = np.minimum(open_data, close) - np.abs(np.random.randn(n))
-        
+
         # 1. Create chart
-        result = plot(
-            index, open_data, high, low, close,
-            session_id='workflow_test',
-            open_browser=False,
-            block=False
-        )
-        assert result['status'] == 'success'
-        
+        result = plot(index, open_data, high, low, close, session_id="workflow_test", open_browser=False, block=False)
+        assert result["status"] == "success"
+
         # 2. Check status
         status = get_server_status()
-        assert status['running'] is True
-        assert status['active_sessions'] >= 1
-        
+        assert status["running"] is True
+        assert status["active_sessions"] >= 1
+
         # 3. Stop server
         stop_server()
-        
+
         # 4. Verify stopped
         status = get_server_status()
-        assert status['running'] is False
-    
+        assert status["running"] is False
+
     def test_multiple_sessions(self):
         """Test creating multiple chart sessions."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
-        
+
         # Create multiple sessions
         for i in range(3):
             result = plot(
-                index, data, data + 1, data - 1, data,
-                session_id=f'session_{i}',
-                open_browser=False,
-                block=False
+                index, data, data + 1, data - 1, data, session_id=f"session_{i}", open_browser=False, block=False
             )
-            assert result['status'] == 'success'
-        
+            assert result["status"] == "success"
+
         # Check all sessions exist
         assert len(_data_managers) >= 3
         for i in range(3):
-            assert f'session_{i}' in _data_managers
+            assert f"session_{i}" in _data_managers
 
 
 class TestReprHtml:
     """Tests for _repr_html_ Jupyter integration."""
 
     def test_repr_html_when_no_server(self):
+        """Verify _repr_html_() reports a stopped state when no server is active."""
         import pycharting.api.interface as iface
+
         original = iface._active_server
         iface._active_server = None
         try:
@@ -335,6 +290,7 @@ class TestReprHtml:
             iface._active_server = original
 
     def test_repr_html_when_server_running(self):
+        """Verify _repr_html_() returns embeddable HTML markup while a server is running."""
         n = 50
         data = np.random.randn(n) + 100
         index = np.arange(n)
@@ -348,7 +304,9 @@ class TestGetServerStatusNullServer:
     """Test get_server_status when _active_server is None."""
 
     def test_returns_not_running_with_none_info(self):
+        """Verify get_server_status() reports not-running with null info when no server is active."""
         import pycharting.api.interface as iface
+
         original = iface._active_server
         iface._active_server = None
         try:
@@ -364,12 +322,17 @@ class TestListInputConversion:
     """Test that list inputs for subplots and trades are converted in plot()."""
 
     def test_plot_with_list_subplots(self):
+        """Verify plot() accepts a subplot whose value is a plain list and succeeds."""
         n = 50
         index = np.arange(n)
         data = np.random.randn(n) + 100
         subplots = {"RSI": list(range(n))}
         result = plot(
-            index, data, data + 1, data - 1, data,
+            index,
+            data,
+            data + 1,
+            data - 1,
+            data,
             subplots=subplots,
             open_browser=False,
             block=False,
@@ -377,12 +340,17 @@ class TestListInputConversion:
         assert result["status"] == "success"
 
     def test_plot_with_list_subplots_dict_format(self):
+        """Verify plot() accepts a subplot dict with list data and a type and succeeds."""
         n = 50
         index = np.arange(n)
         data = np.random.randn(n) + 100
         subplots = {"Vol": {"data": list(range(n)), "type": "bar"}}
         result = plot(
-            index, data, data + 1, data - 1, data,
+            index,
+            data,
+            data + 1,
+            data - 1,
+            data,
             subplots=subplots,
             open_browser=False,
             block=False,
@@ -390,12 +358,17 @@ class TestListInputConversion:
         assert result["status"] == "success"
 
     def test_plot_with_list_subplots_multi_series(self):
+        """Verify plot() accepts a subplot defined as a list of series dicts and succeeds."""
         n = 50
         index = np.arange(n)
         data = np.random.randn(n) + 100
         subplots = {"MACD": [{"data": list(range(n)), "type": "line"}, {"data": list(range(n)), "type": "bar"}]}
         result = plot(
-            index, data, data + 1, data - 1, data,
+            index,
+            data,
+            data + 1,
+            data - 1,
+            data,
             subplots=subplots,
             open_browser=False,
             block=False,
@@ -403,12 +376,17 @@ class TestListInputConversion:
         assert result["status"] == "success"
 
     def test_plot_with_list_trades(self):
+        """Verify plot() accepts a plain list of trade markers and succeeds."""
         n = 50
         index = np.arange(n)
         data = np.random.randn(n) + 100
         trades = [0] * n
         result = plot(
-            index, data, data + 1, data - 1, data,
+            index,
+            data,
+            data + 1,
+            data - 1,
+            data,
             trades=trades,
             open_browser=False,
             block=False,

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,148 +1,150 @@
 """Tests for server lifecycle management."""
 
-import pytest
-import time
 import threading
+import time
+
+import pytest
+
 from src.pycharting.core.lifecycle import ChartServer
 
 
 class TestChartServer:
     """Tests for ChartServer lifecycle management."""
-    
+
     def test_init(self):
         """Test ChartServer initialization."""
         server = ChartServer(host="127.0.0.1")
         assert server.host == "127.0.0.1"
         assert server.port > 0
         assert not server.is_running
-    
+
     def test_init_with_port(self):
         """Test ChartServer with specific port."""
         server = ChartServer(host="127.0.0.1", port=9999)
         assert server.port == 9999
-    
+
     def test_start_server(self):
         """Test starting the server."""
         server = ChartServer()
-        
+
         try:
             info = server.start_server()
-            
+
             assert server.is_running
             assert "url" in info
             assert "ws_url" in info
             assert info["running"]
             assert info["port"] == server.port
-            
+
             # Give server time to fully start
             time.sleep(0.5)
             assert server.is_running
-            
+
         finally:
             server.stop_server()
-    
+
     def test_stop_server(self):
         """Test stopping the server."""
         server = ChartServer()
-        
+
         server.start_server()
         time.sleep(0.5)
         assert server.is_running
-        
+
         server.stop_server()
         time.sleep(0.5)
         assert not server.is_running
-    
+
     def test_cannot_start_twice(self):
         """Test that server cannot be started twice."""
         server = ChartServer()
-        
+
         try:
             server.start_server()
             time.sleep(0.5)
-            
+
             with pytest.raises(RuntimeError, match="already running"):
                 server.start_server()
-        
+
         finally:
             server.stop_server()
-    
+
     def test_stop_when_not_running(self):
         """Test stopping server when it's not running (should not error)."""
         server = ChartServer()
         # Should not raise an error
         server.stop_server()
-    
+
     def test_server_info(self):
         """Test server_info property."""
         server = ChartServer()
-        
+
         info = server.server_info
         assert "host" in info
         assert "port" in info
         assert "running" in info
         assert not info["running"]
-        
+
         try:
             server.start_server()
             time.sleep(0.5)
-            
+
             info = server.server_info
             assert info["running"]
             assert "websocket_connected" in info
             assert "last_heartbeat" in info
-        
+
         finally:
             server.stop_server()
-    
+
     def test_context_manager(self):
         """Test using ChartServer as context manager."""
         with ChartServer() as server:
             time.sleep(0.5)
             assert server.is_running
-        
+
         # Server should be stopped after context exit
         time.sleep(0.5)
         assert not server.is_running
-    
+
     def test_repr(self):
         """Test string representation."""
         server = ChartServer(host="127.0.0.1", port=8888)
         repr_str = repr(server)
-        
+
         assert "ChartServer" in repr_str
         assert "127.0.0.1" in repr_str
         assert "8888" in repr_str
         assert "stopped" in repr_str
-    
+
     def test_background_thread_created(self):
         """Test that server runs in background thread."""
         server = ChartServer()
-        
+
         # Get initial thread count
         initial_threads = threading.active_count()
-        
+
         try:
             server.start_server()
             time.sleep(0.5)
-            
+
             # Should have additional threads
             current_threads = threading.active_count()
             assert current_threads > initial_threads
-            
+
         finally:
             server.stop_server()
             time.sleep(0.5)
-    
+
     def test_auto_shutdown_timeout_configured(self):
         """Test that auto_shutdown_timeout is configurable."""
         server = ChartServer(auto_shutdown_timeout=10.0)
         assert server.auto_shutdown_timeout == 10.0
-    
+
     def test_websocket_endpoint_added(self):
         """Test that WebSocket endpoint is added to app."""
         server = ChartServer()
-        
+
         # Check that the WebSocket route exists
         routes = [route.path for route in server.app.routes]
         assert "/ws/heartbeat" in routes
@@ -150,34 +152,34 @@ class TestChartServer:
 
 class TestThreadSafety:
     """Tests for thread safety."""
-    
+
     def test_multiple_operations(self):
         """Test multiple start/stop operations."""
         server = ChartServer()
-        
-        for i in range(3):
+
+        for _i in range(3):
             server.start_server()
             time.sleep(0.3)
             assert server.is_running
-            
+
             server.stop_server()
             time.sleep(0.3)
             assert not server.is_running
-    
+
     def test_server_cleanup(self):
         """Test that server properly cleans up resources."""
         server = ChartServer()
-        
+
         server.start_server()
         time.sleep(0.5)
-        
+
         # Get thread references
         server_thread = server._server_thread
         monitor_thread = server._monitor_thread
-        
+
         server.stop_server()
         time.sleep(1)
-        
+
         # Threads should be finished
         if server_thread:
             assert not server_thread.is_alive()
@@ -187,48 +189,48 @@ class TestThreadSafety:
 
 class TestServerIntegration:
     """Integration tests for server functionality."""
-    
+
     def test_server_responds_after_start(self):
         """Test that server responds to requests after starting."""
         import httpx
-        
+
         server = ChartServer()
-        
+
         try:
             info = server.start_server()
             time.sleep(1)  # Give server time to start
-            
+
             # Try to access health endpoint
             response = httpx.get(f"{info['url']}/health", timeout=5)
             assert response.status_code == 200
             data = response.json()
             assert data["status"] == "healthy"
-        
+
         except Exception as e:
             pytest.skip(f"Server integration test skipped: {e}")
-        
+
         finally:
             server.stop_server()
-    
+
     def test_server_accessible_in_background(self):
         """Test that main thread is not blocked."""
         import httpx
-        
+
         server = ChartServer()
-        
+
         try:
             server.start_server()
             time.sleep(1)
-            
+
             # Main thread should not be blocked
             # We should be able to make multiple requests
             for _ in range(3):
                 response = httpx.get(f"http://{server.host}:{server.port}/health", timeout=5)
                 assert response.status_code == 200
                 time.sleep(0.1)
-        
+
         except Exception as e:
             pytest.skip(f"Integration test skipped: {e}")
-        
+
         finally:
             server.stop_server()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,8 @@
 
 import pytest
 from fastapi.testclient import TestClient
-from pycharting.core.server import create_app, find_free_port, run_server, NoCacheStaticFiles
+
+from pycharting.core.server import NoCacheStaticFiles, create_app, find_free_port, run_server
 
 
 @pytest.fixture
@@ -14,23 +15,24 @@ def client():
 
 class TestFindFreePort:
     """Tests for find_free_port function."""
-    
+
     def test_finds_free_port(self):
         """Test that a free port is found."""
         port = find_free_port(8000, 8100)
         assert 8000 <= port < 8100
-    
+
     def test_finds_different_ports(self):
         """Test that different calls can find different ports."""
         port1 = find_free_port(8000, 8100)
         port2 = find_free_port(8100, 8200)
         assert port1 != port2 or port1 < 8100
-    
+
     def test_raises_on_no_free_port(self):
         """Test that RuntimeError is raised when no port is free."""
         import socket
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(('127.0.0.1', 0))
+            s.bind(("127.0.0.1", 0))
             occupied_port = s.getsockname()[1]
             with pytest.raises(RuntimeError, match="No free port found"):
                 find_free_port(occupied_port, occupied_port + 1)
@@ -38,11 +40,11 @@ class TestFindFreePort:
 
 class TestAppCreation:
     """Tests for create_app function."""
-    
+
     def test_app_created(self, client):
         """Test that app is created successfully."""
         assert client is not None
-    
+
     def test_app_has_cors(self, client):
         """Test that CORS middleware is configured."""
         response = client.options("/health")
@@ -52,20 +54,20 @@ class TestAppCreation:
 
 class TestRootEndpoint:
     """Tests for root endpoint."""
-    
+
     def test_root_returns_html(self, client):
         """Test that root endpoint returns HTML."""
         response = client.get("/")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
         assert "PyCharting" in response.text
-    
+
     def test_root_has_welcome_message(self, client):
         """Test that root page has welcome message."""
         response = client.get("/")
         assert "Welcome to PyCharting" in response.text
         assert "server is running successfully" in response.text
-    
+
     def test_root_has_api_docs_link(self, client):
         """Test that root page links to API docs."""
         response = client.get("/")
@@ -74,24 +76,24 @@ class TestRootEndpoint:
 
 class TestHealthCheck:
     """Tests for health check endpoint."""
-    
+
     def test_health_check_returns_200(self, client):
         """Test that health check returns 200."""
         response = client.get("/health")
         assert response.status_code == 200
-    
+
     def test_health_check_returns_json(self, client):
         """Test that health check returns JSON."""
         response = client.get("/health")
         assert response.headers["content-type"] == "application/json"
-    
+
     def test_health_check_has_status(self, client):
         """Test that health check includes status."""
         response = client.get("/health")
         data = response.json()
         assert "status" in data
         assert data["status"] == "healthy"
-    
+
     def test_health_check_has_service_name(self, client):
         """Test that health check includes service name."""
         response = client.get("/health")
@@ -102,7 +104,7 @@ class TestHealthCheck:
 
 class TestStaticFiles:
     """Tests for static file serving."""
-    
+
     def test_static_route_exists(self, client):
         """Test that static route is mounted."""
         # This will return 404 if no file exists, but route should be there
@@ -113,31 +115,31 @@ class TestStaticFiles:
 
 class TestAPIDocumentation:
     """Tests for API documentation endpoints."""
-    
+
     def test_openapi_json_available(self, client):
         """Test that OpenAPI JSON is available."""
         response = client.get("/openapi.json")
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/json"
-    
+
     def test_openapi_has_title(self, client):
         """Test that OpenAPI spec has correct title."""
         response = client.get("/openapi.json")
         data = response.json()
         assert data["info"]["title"] == "PyCharting"
-    
+
     def test_openapi_has_version(self, client):
         """Test that OpenAPI spec has version."""
         response = client.get("/openapi.json")
         data = response.json()
         assert data["info"]["version"] == "0.1.0"
-    
+
     def test_docs_endpoint_available(self, client):
         """Test that docs UI is available."""
         response = client.get("/api/docs")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-    
+
     def test_redoc_endpoint_available(self, client):
         """Test that ReDoc UI is available."""
         response = client.get("/api/redoc")
@@ -147,12 +149,12 @@ class TestAPIDocumentation:
 
 class TestErrorHandling:
     """Tests for error handling."""
-    
+
     def test_404_on_nonexistent_route(self, client):
         """Test that 404 is returned for nonexistent routes."""
         response = client.get("/nonexistent")
         assert response.status_code == 404
-    
+
     def test_404_returns_json(self, client):
         """Test that 404 error returns JSON."""
         response = client.get("/api/nonexistent")
@@ -162,14 +164,14 @@ class TestErrorHandling:
 
 class TestCORS:
     """Tests for CORS configuration."""
-    
+
     def test_cors_headers_on_health_check(self, client):
         """Test that CORS headers are present."""
         response = client.get("/health", headers={"Origin": "http://localhost:3000"})
         # CORS middleware should add headers
         assert response.status_code == 200
         # FastAPI's TestClient might not fully simulate CORS, but endpoint should work
-    
+
     def test_endpoint_accessible(self, client):
         """Test that endpoints are accessible (CORS doesn't block)."""
         response = client.get("/health")
@@ -178,12 +180,12 @@ class TestCORS:
 
 class TestAppMetadata:
     """Tests for app metadata."""
-    
+
     def test_app_has_correct_metadata(self, client):
         """Test that app metadata is correct."""
         response = client.get("/openapi.json")
         data = response.json()
-        
+
         assert data["info"]["title"] == "PyCharting"
         assert data["info"]["description"] == "Interactive charting and data visualization API"
         assert data["info"]["version"] == "0.1.0"
@@ -193,7 +195,9 @@ class TestNoCacheStaticFiles:
     """Tests for NoCacheStaticFiles middleware."""
 
     def test_adds_no_cache_headers(self, tmp_path):
+        """Verify NoCacheStaticFiles serves files with no-cache headers."""
         from fastapi import FastAPI
+
         test_file = tmp_path / "test.txt"
         test_file.write_text("hello")
 
@@ -212,7 +216,9 @@ class TestRunServer:
     """Tests for run_server function."""
 
     def test_run_server_auto_port(self):
-        from unittest.mock import patch, MagicMock
+        """Verify run_server selects a positive port automatically by default."""
+        from unittest.mock import MagicMock, patch
+
         with patch("pycharting.core.server.uvicorn") as mock_uvicorn:
             mock_uvicorn.run = MagicMock()
             run_server()
@@ -220,8 +226,10 @@ class TestRunServer:
             assert mock_uvicorn.run.call_args.kwargs["port"] > 0
 
     def test_run_server_specific_port(self):
+        """Verify run_server uses the given port when auto_port is disabled."""
         import socket
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("", 0))
             free_port = s.getsockname()[1]
@@ -231,14 +239,18 @@ class TestRunServer:
             assert mock_uvicorn.run.call_args.kwargs["port"] == free_port
 
     def test_run_server_auto_port_fallback(self):
+        """Verify run_server falls back to a free port when the requested port is occupied."""
         import socket
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
             occupied = s.getsockname()[1]
             fallback = occupied + 1
-            with patch("pycharting.core.server.uvicorn") as mock_uvicorn, \
-                 patch("pycharting.core.server.find_free_port", return_value=fallback) as mock_ffp:
+            with (
+                patch("pycharting.core.server.uvicorn") as mock_uvicorn,
+                patch("pycharting.core.server.find_free_port", return_value=fallback) as mock_ffp,
+            ):
                 mock_uvicorn.run = MagicMock()
                 run_server(host="127.0.0.1", port=occupied, auto_port=True)
                 mock_ffp.assert_called_once_with(occupied + 1)


### PR DESCRIPTION
## Summary

Makes `make fmt` pass cleanly on the branch by resolving all 83 ruff
findings and the `interrogate` docstring-coverage gate (72.6% → 96.8%).

This branch contains two commits:
1. `Restore rhiza template files via make sync` (pre-existing)
2. `Fix make fmt: resolve ruff lint and docstring coverage failures`

### Lint/docstring fixes
- **`__init__.py`** — drop unused/deprecated `typing` imports (F401, UP035)
- **`api/routes.py`** — `raise ... from e` (B904), trim redundant
  `logger.exception` args (TRY401), rename ambiguous `l` (E741),
  return via `else` (TRY300)
- **`api/interface.py`** — wrap long docstring lines (E501), document
  `trades` (D417), return via `else` (TRY300)
- **`core/lifecycle.py`** — wrap docstring line, trim `logger.exception` (TRY401)
- **`core/server.py`** — add `get_response` docstring (D102)
- **`data/ingestion.py`** — document `trades` (D417), if/else → ternaries
  (SIM108), docstrings for `__init__`, properties, dunders and `get_chunk`
- **tests** — add docstrings to flagged test methods (D102), raw-string a
  `pytest.raises(match=...)` pattern (RUF043)

### Notes
- Informative validation messages keep targeted `# noqa: TRY003` rather
  than being refactored into exception subclasses.
- `ruff.toml` is intentionally left untouched as it is rhiza-template-managed.
- No test logic or assertions were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)