### PR TITLE
Fix Windows tests, typecheck errors, and reach 100% coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Office/Business :: Financial",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
@@ -27,17 +29,26 @@ dependencies = [
     "uvicorn[standard]>=0.24.0,<1.0.0",
 ]
 
-[project.optional-dependencies]
-dev = [
+[dependency-groups]
+# Test-only tooling, used under tests/ (which deptry does not scan), not in the
+# src/ package. Declared as PEP 735 dependency groups so `uv run` installs them
+# by default (see [tool.uv].default-groups) — this keeps `uv run pytest` working
+# without `--all-extras`, including under `--resolution lowest-direct`. httpx is
+# required transitively by fastapi.testclient but must be pinned directly so the
+# lowest-direct resolver still installs it.
+test = [
     "pytest>=8.3.0,<9.0.0",
     "pytest-cov>=6.0.0",
     "httpx>=0.27.0,<0.29.0",
 ]
+lint = [
+    "ruff>=0.6.0",
+]
 
-[tool.deptry]
-# The "dev" optional-dependency group holds test-only tooling that is used
-# under tests/ (which deptry does not scan), not in the src/ package.
-pep621_dev_dependency_groups = ["dev"]
+[tool.uv]
+# Install the test and lint groups by default so `uv run` has them available
+# without an explicit `--group`/`--all-groups` flag.
+default-groups = ["test", "lint"]
 
 [project.urls]
 Homepage = "https://github.com/alihaskar/pycharting"

--- a/src/pycharting/__init__.py
+++ b/src/pycharting/__init__.py
@@ -38,7 +38,7 @@ Exports:
     - `get_server_status`: Function to check the status of the background server.
 """
 
-from .api.interface import get_server_status, plot, stop_server  # type: ignore F401
+from .api.interface import get_server_status, plot, stop_server
 
 __all__ = ["__version__", "get_server_status", "plot", "stop_server"]
 

--- a/src/pycharting/api/interface.py
+++ b/src/pycharting/api/interface.py
@@ -17,14 +17,14 @@ and Jupyter notebook integration.
 import logging
 import time
 import webbrowser
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
 
 from pycharting.api.routes import _data_managers
 from pycharting.core.lifecycle import ChartServer
-from pycharting.data.ingestion import DataManager
+from pycharting.data.ingestion import DataManager, SubplotSpec
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ def plot(
     low: np.ndarray | pd.Series | list | None = None,
     close: np.ndarray | pd.Series | list | None = None,
     overlays: dict[str, np.ndarray | pd.Series | list] | None = None,
-    subplots: dict[str, np.ndarray | pd.Series | list] | None = None,
+    subplots: dict[str, SubplotSpec] | None = None,
     trades: np.ndarray | pd.Series | list | None = None,
     session_id: str = "default",
     port: int | None = None,
@@ -141,7 +141,7 @@ def plot(
             overlays = {k: np.array(v) if isinstance(v, list) else v for k, v in overlays.items()}
 
         if subplots:
-            converted = {}
+            converted: dict[str, SubplotSpec] = {}
             for k, v in subplots.items():
                 if isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
                     converted[k] = [
@@ -155,7 +155,7 @@ def plot(
                     ]
                 elif isinstance(v, dict):
                     d = v.get("data")
-                    converted[k] = {**v, "data": np.array(d) if isinstance(d, list) else d}
+                    converted[k] = cast("dict[str, Any]", {**v, "data": np.array(d) if isinstance(d, list) else d})
                 else:
                     converted[k] = np.array(v) if isinstance(v, list) else v
             subplots = converted

--- a/src/pycharting/data/ingestion.py
+++ b/src/pycharting/data/ingestion.py
@@ -9,10 +9,15 @@ This module is responsible for:
 The `DataManager` class is the core component here, acting as the optimized data store for a chart session.
 """
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
+
+# A single subplot panel may be supplied as a plain array, as a config dict
+# ({"data": ..., "type": ..., "color": ..., "label": ...}), or as a list of such
+# dicts for a multi-series panel.
+SubplotSpec = pd.Series | np.ndarray | list | dict[str, Any]
 
 
 class DataValidationError(Exception):
@@ -22,13 +27,13 @@ class DataValidationError(Exception):
 
 
 def validate_input(
-    index: pd.Index | np.ndarray,
+    index: pd.Index | pd.Series | np.ndarray,
     open: pd.Series | np.ndarray | None = None,
     high: pd.Series | np.ndarray | None = None,
     low: pd.Series | np.ndarray | None = None,
     close: pd.Series | np.ndarray | None = None,
-    overlays: dict[str, pd.Series | np.ndarray] | None = None,
-    subplots: dict[str, pd.Series | np.ndarray] | None = None,
+    overlays: dict[str, pd.Series | np.ndarray | list] | None = None,
+    subplots: dict[str, SubplotSpec] | None = None,
     trades: pd.Series | np.ndarray | list | None = None,
 ) -> dict[str, Any]:
     """Validate and normalize input data for OHLC charting.
@@ -51,7 +56,7 @@ def validate_input(
         DataValidationError: If any validation check fails.
     """
     # Convert index to numpy array if needed
-    if isinstance(index, pd.Index):
+    if isinstance(index, (pd.Index, pd.Series)):
         index_array = index.to_numpy()
     elif isinstance(index, np.ndarray):
         index_array = index
@@ -150,11 +155,14 @@ def validate_input(
     trades_arr = None
     if trades is not None:
         trades_arr = to_array(trades, "Trades")
-        unique = set(np.unique(trades_arr).tolist())
-        valid_vals = {-1, 0, 1, -1.0}
-        if not unique.issubset(valid_vals):
-            raise DataValidationError(f"Trades array must contain only -1, 0, or 1. Found: {unique - valid_vals}")  # noqa: TRY003
-        trades_arr = trades_arr.astype(np.int8)
+        if trades_arr is not None:
+            unique = set(np.unique(trades_arr).tolist())
+            valid_vals = {-1, 0, 1, -1.0}
+            if not unique.issubset(valid_vals):
+                raise DataValidationError(  # noqa: TRY003
+                    f"Trades array must contain only -1, 0, or 1. Found: {unique - valid_vals}"
+                )
+            trades_arr = trades_arr.astype(np.int8)
 
     result = {
         "index": index_array,
@@ -183,7 +191,8 @@ def validate_input(
         for name, value in subplots.items():
             if isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
                 panel_series = []
-                for idx, entry in enumerate(value):
+                for idx, raw_entry in enumerate(value):
+                    entry = cast("dict[str, Any]", raw_entry)
                     key = f"{name}__{idx}"
                     arr = to_array(entry.get("data"), f"Subplot '{name}[{idx}]'")
                     result["subplots"][key] = arr
@@ -197,13 +206,14 @@ def validate_input(
                     )
                 subplot_meta[name] = panel_series
             elif isinstance(value, dict):
-                arr = to_array(value.get("data"), f"Subplot '{name}'")
+                spec = cast("dict[str, Any]", value)
+                arr = to_array(spec.get("data"), f"Subplot '{name}'")
                 result["subplots"][name] = arr
                 subplot_meta[name] = [
                     {
                         "key": name,
-                        "type": value.get("type", "line"),
-                        "color": value.get("color"),
+                        "type": spec.get("type", "line"),
+                        "color": spec.get("color"),
                         "label": name,
                     }
                 ]
@@ -228,13 +238,13 @@ class DataManager:
 
     def __init__(
         self,
-        index: pd.Index | np.ndarray,
+        index: pd.Index | pd.Series | np.ndarray,
         open: pd.Series | np.ndarray | None = None,
         high: pd.Series | np.ndarray | None = None,
         low: pd.Series | np.ndarray | None = None,
         close: pd.Series | np.ndarray | None = None,
-        overlays: dict[str, pd.Series | np.ndarray] | None = None,
-        subplots: dict[str, pd.Series | np.ndarray] | None = None,
+        overlays: dict[str, pd.Series | np.ndarray | list] | None = None,
+        subplots: dict[str, SubplotSpec] | None = None,
         trades: pd.Series | np.ndarray | list | None = None,
     ):
         """Validate the supplied series and store the normalized arrays for fast slicing."""

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -173,7 +173,10 @@ class TestDataManager:
         low = np.array([99, 100, 99])
         close = np.array([104, 103, 104])
 
-        dm = DataManager(index, open_data, high, low, close)
+        trades = np.array([1, 0, -1])
+        subplots = {"Volume": {"data": np.array([10, 20, 30]), "type": "bar"}}
+
+        dm = DataManager(index, open_data, high, low, close, subplots=subplots, trades=trades)
 
         assert np.array_equal(dm.index, index)
         assert np.array_equal(dm.open, open_data)
@@ -182,6 +185,8 @@ class TestDataManager:
         assert np.array_equal(dm.close, close)
         assert isinstance(dm.overlays, dict)
         assert isinstance(dm.subplots, dict)
+        assert np.array_equal(dm.trades, trades)
+        assert dm.subplot_meta["Volume"][0]["type"] == "bar"
 
     def test_with_overlays_and_subplots(self):
         """Test initialization with overlays and subplots."""
@@ -403,6 +408,16 @@ class TestValidateInputEdgeCases:
         low = np.array([99, 100, 99, 101, 100])
         result = validate_input(index, open_data, high, low, None)
         assert np.array_equal(result["close"], open_data)
+
+    def test_open_close_fallback_when_both_none(self):
+        """When neither open nor close is given, both fall back to the first provided series."""
+        index = np.arange(5)
+        high = np.array([106, 108, 107, 109, 108])
+        low = np.array([99, 100, 99, 101, 100])
+        result = validate_input(index, None, high, low, None)
+        # high is the first provided series, so open and close both default to it.
+        assert np.array_equal(result["open"], high)
+        assert np.array_equal(result["close"], high)
 
     def test_high_auto_computed(self):
         """Verify high is auto-computed as the element-wise maximum of open and close."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,12 +27,25 @@ class TestFindFreePort:
         port2 = find_free_port(8100, 8200)
         assert port1 != port2 or port1 < 8100
 
+    def test_scans_from_start_with_default_end(self):
+        """When only start_port is given, the end of the range defaults to start_port + 1000."""
+        port = find_free_port(8000)
+        assert 8000 <= port < 9000
+
+    def test_returns_ephemeral_port_with_no_arguments(self):
+        """With no arguments, an OS-assigned ephemeral port is returned."""
+        port = find_free_port()
+        assert port > 0
+
     def test_raises_on_no_free_port(self):
         """Test that RuntimeError is raised when no port is free."""
         import socket
 
+        # Bind on the same interface find_free_port scans ("" / all interfaces).
+        # On Windows, 127.0.0.1:port does not conflict with 0.0.0.0:port, so the
+        # occupied port must be claimed on the same address to be seen as taken.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("127.0.0.1", 0))
+            s.bind(("", 0))
             occupied_port = s.getsockname()[1]
             with pytest.raises(RuntimeError, match="No free port found"):
                 find_free_port(occupied_port, occupied_port + 1)

--- a/uv.lock
+++ b/uv.lock
@@ -392,8 +392,11 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
-dev = [
+[package.dev-dependencies]
+lint = [
+    { name = "ruff" },
+]
+test = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -402,15 +405,19 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0,<0.29.0" },
     { name = "numpy", specifier = ">=1.26.0,<3.0.0" },
     { name = "pandas", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.7.0,<3.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1.0.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+lint = [{ name = "ruff", specifier = ">=0.6.0" }]
+test = [
+    { name = "httpx", specifier = ">=0.27.0,<0.29.0" },
+    { name = "pytest", specifier = ">=8.3.0,<9.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
 
 [[package]]
 name = "pydantic"
@@ -564,11 +571,11 @@ wheels = [
 
 [[package]]
 name = "pytz"
-version = "2025.2"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -618,6 +625,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -628,15 +660,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Fix the broken Windows test** (`test_raises_on_no_free_port`). The test bound the "occupied" socket to `127.0.0.1`, but `find_free_port` scans the all-interfaces address (`""` / `0.0.0.0`). On Windows `127.0.0.1:port` does **not** conflict with `0.0.0.0:port`, so the port was seen as free and the expected `RuntimeError` was never raised. The test now binds on the same interface `find_free_port` scans. (CI: [run 27465814364](https://github.com/alihaskar/pycharting/actions/runs/27465814364/job/81187844342))
- **Resolve all `make typecheck` (ty) errors.** Widened the data-ingestion type signatures to match the formats the code actually accepts:
  - subplot values may be plain arrays, config dicts, or lists of dicts → new `SubplotSpec` alias
  - `index` may be a `pd.Series`
  - overlay values may be lists
  - narrowed `trades` before `np.unique`/`astype`, cast already-verified dict shapes, and dropped a malformed `# type: ignore F401`
- **Test coverage to 100%** — added tests for `find_free_port`'s default-range and no-argument paths, the open/close-both-`None` fallback, and the `subplot_meta`/`trades` property getters.

## Test plan
- `make typecheck` → all checks pass
- `uv run pytest --cov=src/pycharting --cov-report=term-missing` → 143 passed, **100%** coverage
- pre-commit hooks (ruff, bandit, interrogate, …) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)