### PR TITLE
Fix code scanning alert: bind socket to 127.0.0.1 instead of all interfaces

### DIFF
--- a/src/pycharting/core/server.py
+++ b/src/pycharting/core/server.py
@@ -78,7 +78,7 @@ def find_free_port(start_port: int | None = None, end_port: int | None = None) -
     if start_port is None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind(("", 0))
+            s.bind(("127.0.0.1", 0))
             return s.getsockname()[1]
 
     if end_port is None:
@@ -87,7 +87,7 @@ def find_free_port(start_port: int | None = None, end_port: int | None = None) -
     for port in range(start_port, end_port):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("", port))
+                s.bind(("127.0.0.1", port))
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 return port
         except OSError:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,11 +41,11 @@ class TestFindFreePort:
         """Test that RuntimeError is raised when no port is free."""
         import socket
 
-        # Bind on the same interface find_free_port scans ("" / all interfaces).
+        # Bind on the same interface find_free_port scans ("127.0.0.1").
         # On Windows, 127.0.0.1:port does not conflict with 0.0.0.0:port, so the
         # occupied port must be claimed on the same address to be seen as taken.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
+            s.bind(("127.0.0.1", 0))
             occupied_port = s.getsockname()[1]
             with pytest.raises(RuntimeError, match="No free port found"):
                 find_free_port(occupied_port, occupied_port + 1)


### PR DESCRIPTION
Resolves the "Binding a socket to all network interfaces" code scanning alert in `find_free_port`.

- `src/pycharting/core/server.py`: bind to `127.0.0.1` instead of `""` (all interfaces).
- `tests/test_server.py`: occupy the test port on `127.0.0.1` so the no-free-port case still conflicts (without this, the test fails on Windows, where `0.0.0.0:port` and `127.0.0.1:port` don't collide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)