### PR TITLE
Fix stop_server coverage gap, add return types, unify console output

### DIFF
--- a/src/pycharting/api/interface.py
+++ b/src/pycharting/api/interface.py
@@ -32,6 +32,20 @@ logger = logging.getLogger(__name__)
 _active_server: ChartServer | None = None
 
 
+def _notify(message: str) -> None:
+    """Emit a user-facing console message.
+
+    All direct, user-facing output (chart URLs, status banners) is funneled
+    through this single helper rather than scattered ``print`` calls, so the
+    output channel is consistent and can be changed in one place. Diagnostic
+    detail continues to flow through ``logger``.
+
+    Args:
+        message (str): The message to display to the user.
+    """
+    print(message)
+
+
 def plot(
     index: np.ndarray | pd.Series | list,
     open: np.ndarray | pd.Series | list | None = None,
@@ -211,7 +225,7 @@ def plot(
                 webbrowser.open(chart_url)
             except Exception as e:
                 logger.warning(f"Could not open browser: {e}")
-                print(f"Please open this URL manually: {chart_url}")
+                _notify(f"Please open this URL manually: {chart_url}")
 
         result = {
             "status": "success",
@@ -223,31 +237,31 @@ def plot(
         }
 
         # Print user-friendly message
-        print("\n✓ Chart created successfully!")
-        print(f"  URL: {chart_url}")
-        print(f"  Data points: {data_manager.length:,}")
+        _notify("\n✓ Chart created successfully!")
+        _notify(f"  URL: {chart_url}")
+        _notify(f"  Data points: {data_manager.length:,}")
         if not open_browser:
-            print("  Open the URL above in your browser to view the chart.")
-        print()
+            _notify("  Open the URL above in your browser to view the chart.")
+        _notify("")
 
         # Block until server shutdown if requested
         if block and _active_server:  # pragma: no cover
             logger.info("Blocking until chart is closed (press Ctrl+C to force exit)...")
-            print("Keeping server alive until you close the browser page...")
+            _notify("Keeping server alive until you close the browser page...")
             try:
                 # Wait with timeout so Ctrl+C can interrupt
                 while not _active_server._shutdown_event.is_set():
                     _active_server._shutdown_event.wait(timeout=0.5)
                 logger.info("Server shutdown detected, returning control")
-                print("\n✓ Chart closed, server stopped")
+                _notify("\n✓ Chart closed, server stopped")
             except KeyboardInterrupt:
                 logger.info("Interrupted by user")
-                print("\n⚠️  Interrupted - stopping server...")
+                _notify("\n⚠️  Interrupted - stopping server...")
                 _active_server.stop_server()
 
     except Exception as e:
         logger.error(f"Error creating chart: {e}", exc_info=True)
-        print(f"\n✗ Error creating chart: {e}\n")
+        _notify(f"\n✗ Error creating chart: {e}\n")
 
         return {
             "status": "error",
@@ -258,7 +272,7 @@ def plot(
         return result
 
 
-def stop_server():
+def stop_server() -> None:
     """Manually shut down the active chart server.
 
     While the server has an auto-shutdown feature (triggered after a timeout when no clients are connected),
@@ -280,9 +294,9 @@ def stop_server():
     if _active_server and _active_server.is_running:
         logger.info("Stopping ChartServer...")
         _active_server.stop_server()
-        print("✓ Chart server stopped")
+        _notify("✓ Chart server stopped")
     else:
-        print("ⓘ No active server to stop")
+        _notify("ⓘ No active server to stop")
 
 
 def get_server_status() -> dict[str, Any]:
@@ -322,7 +336,7 @@ def get_server_status() -> dict[str, Any]:
 
 
 # Jupyter notebook support
-def _repr_html_():
+def _repr_html_() -> str:
     """Jupyter notebook representation."""
     status = get_server_status()
     if status["running"]:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -5,28 +5,30 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from pycharting.api.interface import _active_server, _repr_html_, get_server_status, plot, stop_server
+from pycharting.api.interface import _repr_html_, get_server_status, plot, stop_server
 from pycharting.api.routes import _data_managers
 
 
 @pytest.fixture(autouse=True)
 def cleanup_globals():
-    """Clean up global state between tests."""
-    global _active_server
+    """Clean up global state between tests.
 
-    # Stop any active server before test
-    if _active_server and _active_server.is_running:
-        _active_server.stop_server()
+    Operates on the live ``interface`` module global rather than a name
+    imported into this module — a plain ``global _active_server`` here would
+    rebind the test module's own copy and leave the running server (and the
+    real ``interface._active_server``) untouched, leaking state between tests.
+    """
+    import pycharting.api.interface as iface
 
-    # Clear data managers
-    _data_managers.clear()
+    def _reset() -> None:
+        if iface._active_server and iface._active_server.is_running:
+            iface._active_server.stop_server()
+        iface._active_server = None
+        _data_managers.clear()
 
+    _reset()
     yield
-
-    # Clean up after test
-    if _active_server and _active_server.is_running:
-        _active_server.stop_server()
-    _data_managers.clear()
+    _reset()
 
 
 class TestPlotFunction:
@@ -165,10 +167,20 @@ class TestStopServer:
         status = get_server_status()
         assert status["running"] is False
 
-    def test_stop_server_when_not_running(self):
-        """Test stopping when no server is active."""
-        # Should not raise an error
-        stop_server()  # Should print info message
+    def test_stop_server_when_not_running(self, capsys):
+        """Test stopping when no server is active reports the no-op message."""
+        import pycharting.api.interface as iface
+
+        # Force the module global to None so the "no active server" branch is
+        # exercised deterministically, regardless of test execution order /
+        # xdist worker state.
+        original = iface._active_server
+        iface._active_server = None
+        try:
+            stop_server()  # Should not raise; should emit the info message
+            assert "No active server to stop" in capsys.readouterr().out
+        finally:
+            iface._active_server = original
 
 
 class TestGetServerStatus:


### PR DESCRIPTION
## Summary

Addresses three quality findings from a Rhiza quality assessment. All changes are confined to `src/pycharting/api/interface.py` and `tests/test_interface.py`.

Tracked in the fork at tschm/pycharting#7, tschm/pycharting#8, tschm/pycharting#9.

## Changes

**7 — Test-isolation / coverage gap (`interface.py:285`)**
The `cleanup_globals` fixture used `global _active_server`, which only rebinds the *test module's* imported copy and never touches `interface._active_server`. The running server therefore leaked across tests, leaving the no-server branch of `stop_server()` uncovered and making `test_status_when_no_server` intermittently fail. The fixture now resets the **live module global** (stop + set `None`) before and after each test; `test_stop_server_when_not_running` forces the no-server branch and asserts on the message. Coverage is back to **100%** and deterministic across repeated runs.

**8 — Return-type annotations**
Added `stop_server() -> None` and `_repr_html_() -> str`, matching the rest of the public API surface.

**9 — Unified console output**
Routed all user-facing console output through a single `_notify()` helper instead of scattered bare `print()` calls. No bare `print()` remains in `src/pycharting/`; visible stdout behavior is preserved.

## Verification

| Gate | Result |
|------|--------|
| `make fmt` | ✅ |
| `make typecheck` | ✅ All checks passed |
| `make docs-coverage` | ✅ 100% |
| `make deptry` | ✅ No issues |
| `make test` | ✅ 143 passed, **100.00%** coverage (×3 consecutive runs) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
