### PR TITLE
fix: mkdocs description + staged error handling in plot() (#56, #50)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 INHERIT: docs/mkdocs-base.yml
 
 site_name: pycharting
-site_description: Add your description here.
+site_description: High-performance financial charting library for OHLC data visualization with technical indicators
 site_url: https://alihaskar.github.io/pycharting/
 repo_url: https://github.com/alihaskar/pycharting
 repo_name: alihaskar/pycharting

--- a/src/pycharting/api/interface.py
+++ b/src/pycharting/api/interface.py
@@ -24,7 +24,7 @@ import pandas as pd
 
 from pycharting.api.routes import _data_managers
 from pycharting.core.lifecycle import ChartServer
-from pycharting.data.ingestion import DataManager, SubplotSpec
+from pycharting.data.ingestion import DataManager, DataValidationError, SubplotSpec
 
 logger = logging.getLogger(__name__)
 
@@ -259,12 +259,27 @@ def plot(
                 _notify("\n⚠️  Interrupted - stopping server...")
                 _active_server.stop_server()
 
+    except DataValidationError as e:
+        # Input data failed validation — the user can fix this by correcting
+        # their arrays before calling plot() again.
+        logger.error(f"Invalid input data: {e}", exc_info=True)
+        _notify(f"\n✗ Invalid input data: {e}\n")
+
+        return {
+            "status": "error",
+            "stage": "validation",
+            "error": str(e),
+            "session_id": session_id,
+        }
     except Exception as e:
+        # Server startup, browser launch, or other runtime failure — not
+        # something the caller's data can fix.
         logger.error(f"Error creating chart: {e}", exc_info=True)
         _notify(f"\n✗ Error creating chart: {e}\n")
 
         return {
             "status": "error",
+            "stage": "server",
             "error": str(e),
             "session_id": session_id,
         }

--- a/tests/pycharting/api/test_interface.py
+++ b/tests/pycharting/api/test_interface.py
@@ -123,6 +123,22 @@ def test_plot_with_invalid_data():
     assert result["stage"] == "validation"
 
 
+def test_plot_server_startup_failure_reported_as_server_stage():
+    """A non-validation failure (e.g. server startup) is reported with stage='server'."""
+    n = 20
+    data = np.random.randn(n) + 100
+    index = np.arange(n)
+
+    # Valid data passes validation, so the error must come from a later stage.
+    with patch("pycharting.api.interface.ChartServer") as mock_server:
+        mock_server.side_effect = RuntimeError("boom: could not start server")
+        result = plot(index, close=data, open_browser=False, block=False)
+
+    assert result["status"] == "error"
+    assert result["stage"] == "server"
+    assert "boom" in result["error"]
+
+
 @patch("webbrowser.open")
 def test_plot_opens_browser(mock_browser):
     """Test that plot opens browser when requested."""

--- a/tests/pycharting/api/test_interface.py
+++ b/tests/pycharting/api/test_interface.py
@@ -119,6 +119,8 @@ def test_plot_with_invalid_data():
 
     assert result["status"] == "error"
     assert "error" in result
+    # A validation failure must be reported as such, distinct from server/runtime errors.
+    assert result["stage"] == "validation"
 
 
 @patch("webbrowser.open")


### PR DESCRIPTION
Addresses three quality issues.

## #56 — Replace placeholder mkdocs `site_description`
`mkdocs.yml` carried the scaffold placeholder `Add your description here.`. Set it to the real description already present in `pyproject.toml` (single source of truth):
> High-performance financial charting library for OHLC data visualization with technical indicators

## #50 — Narrow broad `except Exception` in `plot()`
The `plot()` body was wrapped in a single broad `except Exception`, collapsing input-validation failures and server/runtime failures into one generic error. Split into:
- `except DataValidationError` → `{"status": "error", "stage": "validation", ...}` — fixable by correcting input arrays.
- `except Exception` → `{"status": "error", "stage": "server", ...}` — server startup / browser / runtime failures.

The `error` key is preserved for backward compatibility. `test_plot_with_invalid_data` now asserts `stage == "validation"`.

## #54 — Failing `test_websocket_endpoint_added`
The test already carries the defensive `getattr(route, "path", None)` guard and passes; closing that issue separately as already-fixed.

## Verification
Full suite: **94 passed**, exit 0.

Closes #56
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)