### PR TITLE
docs: add docstrings to nested test helpers (#64)

### DIFF
--- a/tests/pycharting/api/test_interface.py
+++ b/tests/pycharting/api/test_interface.py
@@ -161,14 +161,18 @@ def test_plot_block_returns_when_shutdown_event_set():
     """
 
     class _Event:
+        """Fake shutdown event that reports "not set" once, then "set"."""
+
         def __init__(self):
             self._checks = 0
 
         def is_set(self):
+            """Return False on the first call, then True, yielding one loop iteration."""
             self._checks += 1
             return self._checks > 1  # False first, then True -> exactly one iteration
 
         def wait(self, timeout=None):
+            """Return immediately — the wait duration is irrelevant to this test."""
             return None
 
     n = 10
@@ -189,10 +193,14 @@ def test_plot_block_handles_keyboard_interrupt():
     """A Ctrl+C during the blocking wait stops the server and still returns success."""
 
     class _InterruptingEvent:
+        """Fake shutdown event whose wait raises ``KeyboardInterrupt``."""
+
         def is_set(self):
+            """Report the event as never set, so ``plot()`` enters the blocking wait."""
             return False
 
         def wait(self, timeout=None):
+            """Simulate a Ctrl+C arriving while the caller is blocked."""
             raise KeyboardInterrupt
 
     n = 10

--- a/tests/pycharting/core/test_lifecycle.py
+++ b/tests/pycharting/core/test_lifecycle.py
@@ -282,6 +282,7 @@ def test_server_responds_after_start(wait_until):
     server = ChartServer()
 
     def _healthy():
+        """Return the health response once it comes back 200, else None to retry."""
         try:
             response = httpx.get(f"http://{server.host}:{server.port}/health", timeout=1)
         except httpx.HTTPError:
@@ -303,6 +304,7 @@ def test_server_accessible_in_background(wait_until):
     server = ChartServer()
 
     def _healthy():
+        """Return the health response once it comes back 200, else None to retry."""
         try:
             response = httpx.get(f"http://{server.host}:{server.port}/health", timeout=1)
         except httpx.HTTPError:


### PR DESCRIPTION
## Summary

Rhiza v1.2.2 widens the `docs-coverage` gate from `${SOURCE_FOLDER}` to `src tests .rhiza/tests`, so helpers defined *inside* test bodies are now scanned by `interrogate --fail-under 100`. Eight were undocumented, putting the gate at 97.4%.

Adds a one-line docstring to each:

| File | Helper |
|---|---|
| `tests/pycharting/api/test_interface.py` | `_Event`, `_Event.is_set`, `_Event.wait` |
| `tests/pycharting/api/test_interface.py` | `_InterruptingEvent`, `.is_set`, `.wait` |
| `tests/pycharting/core/test_lifecycle.py` | `_healthy` (×2) |

`__init__` needs none — the gate runs with `--ignore-init-method`.

## Verification

```
$ interrogate --fail-under 100 --ignore-init-method --ignore-magic src tests
RESULT: PASSED (minimum: 100.0%, actual: 100.0%)

$ make test
154 passed — Total coverage: 100.00%
```

Note: on `master` (rhiza v0.18.8) the gate only scans `src/`, so it passes there already; this was verified against the v1.2.2 scope that surfaced it.

Tests-only change — no `src/` or behaviour touched.

Closes #64