### PR TITLE
Derive the version from distribution metadata in one place

### DIFF
--- a/src/pycharting/__init__.py
+++ b/src/pycharting/__init__.py
@@ -38,9 +38,13 @@ Exports:
     - `get_server_status`: Function to check the status of the background server.
 """
 
+from importlib.metadata import version as _distribution_version
+
 from .api.interface import get_server_status, plot, stop_server
 
 __all__ = ["__version__", "get_server_status", "plot", "stop_server"]
 
-# Keep this in sync with pyproject.toml
-__version__ = "0.2.14"
+# Resolved from the installed distribution metadata, which is generated from the
+# version in pyproject.toml. That is the single place to bump; nothing here needs
+# to be kept in sync by hand.
+__version__ = _distribution_version("pycharting")

--- a/src/pycharting/core/server.py
+++ b/src/pycharting/core/server.py
@@ -16,6 +16,7 @@ Key Responsibilities:
 import logging
 import socket
 from collections.abc import MutableMapping
+from importlib.metadata import version as _distribution_version
 from pathlib import Path
 from typing import Any
 
@@ -118,7 +119,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="PyCharting",
         description="Interactive charting and data visualization API",
-        version="0.1.0",
+        version=_distribution_version("pycharting"),
         docs_url="/api/docs",
         redoc_url="/api/redoc",
     )

--- a/tests/pycharting/core/test_server.py
+++ b/tests/pycharting/core/test_server.py
@@ -1,8 +1,11 @@
 """Tests for FastAPI server."""
 
+from importlib.metadata import version as distribution_version
+
 import pytest
 from fastapi.testclient import TestClient
 
+import pycharting
 from pycharting.core.server import NoCacheStaticFiles, create_app, find_free_port, run_server
 
 
@@ -136,10 +139,10 @@ def test_openapi_has_title(client):
 
 
 def test_openapi_has_version(client):
-    """Test that OpenAPI spec has version."""
+    """The OpenAPI spec advertises the installed distribution version."""
     response = client.get("/openapi.json")
     data = response.json()
-    assert data["info"]["version"] == "0.1.0"
+    assert data["info"]["version"] == distribution_version("pycharting")
 
 
 def test_docs_endpoint_available(client):
@@ -190,7 +193,19 @@ def test_app_has_correct_metadata(client):
 
     assert data["info"]["title"] == "PyCharting"
     assert data["info"]["description"] == "Interactive charting and data visualization API"
-    assert data["info"]["version"] == "0.1.0"
+    assert data["info"]["version"] == distribution_version("pycharting")
+
+
+def test_advertised_version_matches_the_package_attribute(client):
+    """The version served over HTTP is the same one ``pycharting.__version__`` reports.
+
+    These used to be independent literals — ``0.1.0`` here and ``0.2.14`` in
+    ``__init__.py``, against ``0.2.16`` in the manifest — and the suite pinned the
+    stale values rather than catching the drift.
+    """
+    served = client.get("/openapi.json").json()["info"]["version"]
+
+    assert served == pycharting.__version__ == distribution_version("pycharting")
 
 
 class TestNoCacheStaticFiles:


### PR DESCRIPTION
Closes #83

## Problem

Three different versions shipped in the same artifact:

| Location | Was |
| --- | --- |
| `pyproject.toml:3` | `0.2.16` |
| `src/pycharting/__init__.py:46` | `0.2.14` |
| `src/pycharting/core/server.py:121` | `0.1.0` |

`pycharting.__version__` was two patch releases stale, and `/api/docs` plus the OpenAPI schema advertised `0.1.0`.

## Change

Both sites now read `importlib.metadata.version("pycharting")`, so the manifest is the only place to bump. `server.py` resolves it directly rather than importing `pycharting.__version__`, which would be circular: `pycharting/__init__` → `api.interface` → `core.lifecycle` → `core.server`.

The `# Keep this in sync with pyproject.toml` comment is gone, because nothing needs syncing by hand now.

## Why the tests didn't catch it

`test_openapi_has_version` and `test_app_has_correct_metadata` asserted the literal `"0.1.0"` — they pinned the stale value rather than detecting the drift, which is how this survived a 100% coverage gate. Both now compare against the distribution metadata, and a new test asserts the served version, `pycharting.__version__` and the metadata all agree.

## Verification

- `make test` — 173 passed (was 172), coverage 100%
- `make typecheck`, `make fmt` — clean
- `pycharting.__version__` and `create_app().version` both resolve to `0.2.16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)