### PR TITLE
Correct the README project-structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,16 +247,17 @@ For a detailed technical deep dive into the architecture, data flow, rendering p
 
 The library follows a modern `src/` layout:
 
-```
+```text
 pycharting/
 ├── src/
-│   ├── core/         # Chart server lifecycle and internals
-│   ├── data/         # Data ingestion, validation, and slicing
-│   ├── api/          # FastAPI routes and Python API surface
-│   └── web/          # Static frontend (HTML + JS for charts)
-├── tests/            # Test suite
-├── data/             # Sample CSVs and fixtures
-└── pyproject.toml    # Project configuration
+│   └── pycharting/
+│       ├── core/         # Chart server lifecycle and internals
+│       ├── data/         # Data ingestion, validation, and slicing
+│       ├── api/          # FastAPI routes and Python API surface
+│       └── web/          # Static frontend (HTML + JS for charts)
+├── tests/                # Test suite, mirroring src/pycharting/
+├── docs/                 # MkDocs sources, incl. how-it-works.md
+└── pyproject.toml        # Project configuration
 ```
 
 ## Contributing


### PR DESCRIPTION
Closes #85

## Problem

The "Project structure" tree described a layout the repo does not have:

- It showed `src/core/`, `src/data/`, `src/api/`, `src/web/`, but the packages live under `src/pycharting/`. The section's own opening line ("The library follows a modern `src/` layout") was right; the tree contradicted it.
- It listed a top-level `data/  # Sample CSVs and fixtures` directory that does not exist.
- It omitted `docs/`, which does exist and holds `how-it-works.md` — linked from the paragraph immediately above.

The fence also carried no language tag, so no tooling could check it:

```
"1 fence(s) carry no language, so nothing can check them: line 250"
```

## Change

The tree now reflects the real layout, drops the non-existent `data/`, adds `docs/`, and is tagged ` ```text `.

## Verification

- `check_doc_examples.py --source-root src` — no untagged fences remain
- `make fmt` — markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)